### PR TITLE
Adding to app views path for sake of e2e

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -12,7 +12,8 @@ app.set("views", [
     path.join(__dirname, "node_modules/govuk-frontend"),
     path.join(__dirname, "../node_modules/govuk-frontend"), // This if for when using ts-node since the working directory is src
     path.join(__dirname, "node_modules/govuk-frontend/components"),
-    path.join(__dirname, "../node_modules/@companieshouse/ch-node-utils/templates/")
+    path.join(__dirname, "../node_modules/@companieshouse/ch-node-utils/templates/"),
+    path.join(__dirname, "node_modules/@companieshouse/ch-node-utils/templates/")
 ]);
 
 const nunjucksLoaderOpts = {


### PR DESCRIPTION
I've added to the path for `ch-node-utils/templates` because I think docker-chs-dev needs one path and e2e another.