### PR TITLE
Removing an unused import 

### DIFF
--- a/src/routers/handlers/start/start.ts
+++ b/src/routers/handlers/start/start.ts
@@ -2,7 +2,6 @@ import { Request, Response } from "express";
 import { BaseViewData, GenericHandler, ViewModel } from "./../generic";
 import logger from "../../../lib/Logger";
 import { PrefixedUrls } from "../../../constants";
-import { LocalesService } from "@companieshouse/ch-node-utils";
 import { selectLang, getLocalesService, getLocaleInfo } from "../../../utils/localise";
 
 export class StartHandler extends GenericHandler<BaseViewData> {


### PR DESCRIPTION
Not used and is pulling in typescript files into the js files in dist.
This may be the causes of e2e not deploying