### PR TITLE
adding a missing comma that's causing template engine to error

### DIFF
--- a/src/views/router_views/personal_code/personal_code.njk
+++ b/src/views/router_views/personal_code/personal_code.njk
@@ -29,7 +29,7 @@
       {{ govukButton({
           text: i18n.global_save_continue_button,
           href: Urls.INDIVIDUAL_STATEMENT,
-          classes: "govuk-!-margin-top-2 govuk-!-margin-bottom-8"
+          classes: "govuk-!-margin-top-2 govuk-!-margin-bottom-8",
           id: "continue"
       }) }}
     </div>


### PR DESCRIPTION
I missed this when I added an id