### PR TITLE
Add user signout bar on all pages except start

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -3,7 +3,7 @@ import nunjucks from "nunjucks";
 import path from "path";
 import logger from "./lib/Logger";
 import routerDispatch from "./router.dispatch";
-import { servicePathPrefix } from "./constants";
+import { servicePathPrefix, ExternalUrls } from "./constants";
 import { sessionMiddleware } from "./middleware/session";
 import cookieParser from "cookie-parser";
 
@@ -43,6 +43,7 @@ njk.addGlobal("cdnUrlCss", process.env.CDN_URL_CSS);
 njk.addGlobal("cdnUrlJs", process.env.CDN_URL_JS);
 njk.addGlobal("cdnHost", process.env.CDN_HOST);
 njk.addGlobal("chsUrl", process.env.CHS_URL);
+njk.addGlobal("ExternalUrls", ExternalUrls);
 
 // If app is behind a front-facing proxy, and to use the X-Forwarded-* headers to determine the connection and the IP address of the client
 app.enable("trust proxy");

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -34,7 +34,8 @@ export const PrefixedUrls = {
 
 export const ExternalUrls = {
     COMPANY_LOOKUP: "/company-lookup/search?forward=" + servicePathPrefix + "/confirm-company?companyNumber={companyNumber}",
-    COMPANY_LOOKUP_WITH_LANG: "/company-lookup/search?forward=" + servicePathPrefix + "/confirm-company?companyNumber={companyNumber}%26lang="
+    COMPANY_LOOKUP_WITH_LANG: "/company-lookup/search?forward=" + servicePathPrefix + "/confirm-company?companyNumber={companyNumber}%26lang=",
+    SIGNOUT: "/signout"
 //     ABILITY_NET: env.ABILITY_NET_LINK,
 //     CONTACT_US: env.CONTACT_US_LINK,
 //     DEVELOPERS: env.DEVELOPERS_LINK,

--- a/src/routers/handlers/generic.ts
+++ b/src/routers/handlers/generic.ts
@@ -46,9 +46,25 @@ export abstract class GenericHandler<T extends BaseViewData> {
         };
     }
 
+    populateViewData (req: Request) {
+        const { signin_info: signInInfo } = req.session?.data ?? {};
+        const isSignedIn = signInInfo?.signed_in !== undefined;
+        this.viewData.isSignedIn = isSignedIn;
+
+        if (!isSignedIn) { return; }
+
+        const userEmail = signInInfo?.user_profile?.email;
+        if (!userEmail) {
+            throw new Error("GenericHandler unable to get email. Email is undefined.");
+        }
+
+        this.viewData.userEmail = userEmail;
+    }
+
     async getViewData (req: Request): Promise<T> {
         this.errorManifest = errorManifest;
         this.viewData = defaultBaseViewData as T;
+        this.populateViewData(req);
         return this.viewData;
     }
 }

--- a/src/routers/handlers/start/start.ts
+++ b/src/routers/handlers/start/start.ts
@@ -17,6 +17,7 @@ export class StartHandler extends GenericHandler<BaseViewData> {
         return {
             ...baseViewData,
             ...getLocaleInfo(locales, lang),
+            isSignedIn: false,
             title: "PSC Verification",
             currentUrl: PrefixedUrls.START,
             backURL: null

--- a/src/views/layouts/default.njk
+++ b/src/views/layouts/default.njk
@@ -15,7 +15,7 @@
 
     <div class="govuk-width-container ">
       {% if isSignedIn %}
-        {% include "../partials/signout-bar.njk" %}
+        {% include "partials/signout-bar.njk" %}
       {% endif %}
 
       {% if backURL %}

--- a/src/views/partials/__meta_header.njk
+++ b/src/views/partials/__meta_header.njk
@@ -5,6 +5,7 @@
     <meta charset="utf-8" />
     <title>{{ title }}</title>
     <link href="{{ cdnHost }}/stylesheets/govuk-frontend/v4.6.0/govuk-frontend-4.6.0.min.css" rel="stylesheet"/>
+    <link href="{{ cdnHost }}/stylesheets/services/presenter-account/application.css" rel="stylesheet"/>
     <link href="{{cdnHost}}/stylesheets/extensions/languages-nav.css" rel="stylesheet"/>
     <link href="{{ cdnUrlCss }}/app.min.css" media="all" rel="stylesheet" type="text/css" />
     <link href="{{ cdnHost }}/images/favicon.ico" rel="icon" type="image/x-icon" />

--- a/src/views/partials/signout-bar.njk
+++ b/src/views/partials/signout-bar.njk
@@ -1,0 +1,8 @@
+{% if userEmail %}
+    {% set email = userEmail | default("Not signed in") %}
+    <div class="signout-bar" id="navigation">
+        <span class="content-email" id="signed-in-user">{{email}}</span>
+        <a class="govuk-link" href="{{ ExternalUrls.SIGNOUT }}" data-event-id="sign-out-button-selected" id="user-signout">Sign Out</a>
+    </div>
+    <script src="{{ cdnHost }}/javascripts/app/session-timeout.js"></script>
+{% endif %}


### PR DESCRIPTION
- avoided display on start page by overriding `isSignedIn` in handler to false

<img width="898" alt="Screenshot 2024-03-26 at 3 26 11 PM" src="https://github.com/companieshouse/psc-verification-web/assets/2736331/7ff90d44-0589-46bf-af1a-d5a6ddca704d">

IDVA3-1126