### PR TITLE
CompanyProfile call - use Oauth2 token instead of API key

### DIFF
--- a/src/routers/handlers/confirmCompany/confirmCompany.ts
+++ b/src/routers/handlers/confirmCompany/confirmCompany.ts
@@ -26,8 +26,7 @@ export class ConfirmCompanyHandler extends GenericHandler<ConfirmCompanyViewData
         const lang = selectLang(req.query.lang);
         const locales = getLocalesService();
 
-        const companyNumber = req.query.companyNumber as string;
-        const companyProfile: CompanyProfile = await getCompanyProfile(companyNumber);
+        const companyProfile: CompanyProfile = await getCompanyProfile(req);
         const company = formatForDisplay(companyProfile, locales, lang);
         const address = buildAddress(companyProfile);
 

--- a/src/services/external/companyProfileService.ts
+++ b/src/services/external/companyProfileService.ts
@@ -1,10 +1,15 @@
+import { Request } from "express";
 import { createApiClient, Resource } from "@companieshouse/api-sdk-node";
 import { CompanyProfile } from "@companieshouse/api-sdk-node/dist/services/company-profile/types";
+import { getAccessToken } from "../../utils/session";
 import logger from "../../lib/Logger";
-import { env } from "../../config";
+import { Session } from "@companieshouse/node-session-handler";
 
-export const getCompanyProfile = async (companyNumber: string): Promise<CompanyProfile> => {
-    const apiClient = createApiClient(env.CHS_API_KEY, undefined, env.API_URL);
+export const getCompanyProfile = async (req: Request): Promise<CompanyProfile> => {
+
+    const accessToken: string = getAccessToken(req.session as Session);
+    const apiClient = createApiClient(undefined, accessToken, undefined);
+    const companyNumber = req.query.companyNumber as string;
 
     logger.debug(`Looking for company profile with company number ${companyNumber}`);
     const sdkResponse: Resource<CompanyProfile> = await apiClient.companyProfile.getCompanyProfile(companyNumber);

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -1,0 +1,19 @@
+import { Session } from "@companieshouse/node-session-handler";
+import { SessionKey } from "@companieshouse/node-session-handler/lib/session/keys/SessionKey";
+import { SignInInfoKeys } from "@companieshouse/node-session-handler/lib/session/keys/SignInInfoKeys";
+import { ISignInInfo } from "@companieshouse/node-session-handler/lib/session/model/SessionInterfaces";
+import { AccessTokenKeys } from "@companieshouse/node-session-handler/lib/session/keys/AccessTokenKeys";
+
+export function getSignInInfo (session: Session): ISignInInfo | undefined {
+    return session?.data?.[SessionKey.SignInInfo];
+}
+
+export function getAccessToken (session: Session): string {
+    const signInInfo = getSignInInfo(session);
+    return signInInfo?.[SignInInfoKeys.AccessToken]?.[AccessTokenKeys.AccessToken] as string;
+}
+
+export const checkUserSignedIn = (session: Session): boolean => {
+    const signInInfo = getSignInInfo(session);
+    return signInInfo?.[SignInInfoKeys.SignedIn] === 1;
+};


### PR DESCRIPTION
Should we be using the customer's Oauth2 token rather than API keys for the  API requests, at least to the public API's?