### PR TITLE
Fix the path for the RLE director template

### DIFF
--- a/src/routers/handlers/rle-director/rleDirector.ts
+++ b/src/routers/handlers/rle-director/rleDirector.ts
@@ -14,7 +14,7 @@ interface RleListViewData extends BaseViewData {
 
 export class RleDirectorHandler extends GenericHandler<RleListViewData> {
 
-    private static templatePath = "router_views/rleDirector/rleDirector";
+    private static templatePath = "router_views/rle-director/rleDirector";
 
     public async getViewData (req: Request): Promise<RleListViewData> {
 


### PR DESCRIPTION
following changes to the folder naming, this path needs to be corrected to allow it to locate the template

re IDVA3-1250