### PR TITLE
Feature/add sign in screen required for psc verification service

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,8 +1,18 @@
 module.exports = {
-    roots: ["<rootDir>"],
-    testPathIgnorePatterns: ["/node_modules/", "/dist/"],
+    roots: [
+        "<rootDir>"
+    ],
+    testPathIgnorePatterns: [
+        "/node_modules/",
+        "/dist/"
+    ],
     collectCoverage: true,
-    coveragePathIgnorePatterns: ["/src/bin/"],
+    collectCoverageFrom: [
+        "./src/**/*.ts"
+    ],
+    coveragePathIgnorePatterns: [
+        "/src/bin/"
+    ],
     preset: "ts-jest",
     testEnvironment: "node",
     verbose: true,
@@ -13,7 +23,5 @@ module.exports = {
     globalSetup: "./test/global.setup.ts",
     moduleNameMapper: {
         "^axios$": require.resolve("axios")
-    },
-    testTimeout: 10000, // Set the timeout to 10 seconds (or any other appropriate value)
-    setupFilesAfterEnv: ["<rootDir>/test/mocks/allMiddleware.mock.ts"]
+    }
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -11,6 +11,9 @@ module.exports = {
         "^.+\\.tsx?$": ["ts-jest", { diagnostics: false }]
     },
     globalSetup: "./test/global.setup.ts",
+    moduleNameMapper: {
+        "^axios$": require.resolve("axios")
+    },
     testTimeout: 10000, // Set the timeout to 10 seconds (or any other appropriate value)
     setupFilesAfterEnv: ["<rootDir>/test/mocks/allMiddleware.mock.ts"]
 };

--- a/src/middleware/authentication.ts
+++ b/src/middleware/authentication.ts
@@ -2,12 +2,13 @@ import { AuthOptions, authMiddleware } from "@companieshouse/web-security-node";
 import { NextFunction, Request, Response } from "express";
 import { env } from "../config";
 
-export const authenticationMiddleware = (req: Request, res: Response, next: NextFunction) => {
+export const authenticate = (req: Request, res: Response, next: NextFunction) => {
     const authMiddlewareConfig: AuthOptions = {
         chsWebUrl: env.CHS_URL,
         returnUrl: req.originalUrl
     };
 
-    return authMiddleware(authMiddlewareConfig)(req, res, next);
+    const authHandler = authMiddleware(authMiddlewareConfig);
+    authHandler(req, res, next);
 
 };

--- a/src/routerDispatch.ts
+++ b/src/routerDispatch.ts
@@ -1,7 +1,7 @@
 // Do Router dispatch here, i.e. map incoming routes to appropriate router
 import { Application, Request, Response, Router } from "express";
 import { Urls, servicePathPrefix } from "./constants";
-import { authenticationMiddleware } from "./middleware/authentication";
+import { authenticate } from "./middleware/authentication";
 import { CompanyNumberRouter, ConfirmCompanyRouter, IndividualPscListRouter, IndividualStatementRouter, PersonalCodeRouter, PscTypeRouter, PscVerifiedRouter, RleDetailsRouter, RleDirectorRouter, RlePscListRouter, StartRouter } from "./routers/utils";
 
 const routerDispatch = (app: Application) => {
@@ -12,16 +12,16 @@ const routerDispatch = (app: Application) => {
 
     router.use("/", StartRouter);
     router.use(Urls.START, StartRouter);
-    router.use(Urls.COMPANY_NUMBER, authenticationMiddleware, CompanyNumberRouter);
-    router.use(Urls.CONFIRM_COMPANY, authenticationMiddleware, ConfirmCompanyRouter);
-    router.use(Urls.PSC_TYPE, authenticationMiddleware, PscTypeRouter);
-    router.use(Urls.INDIVIDUAL_PSC_LIST, authenticationMiddleware, IndividualPscListRouter);
-    router.use(Urls.PERSONAL_CODE, authenticationMiddleware, PersonalCodeRouter);
-    router.use(Urls.INDIVIDUAL_STATEMENT, authenticationMiddleware, IndividualStatementRouter);
-    router.use(Urls.PSC_VERIFIED, authenticationMiddleware, PscVerifiedRouter);
-    router.use(Urls.RLE_LIST, authenticationMiddleware, RlePscListRouter);
-    router.use(Urls.RLE_DETAILS, authenticationMiddleware, RleDetailsRouter);
-    router.use(Urls.RLE_DIRECTOR, authenticationMiddleware, RleDirectorRouter);
+    router.use(Urls.COMPANY_NUMBER, authenticate, CompanyNumberRouter);
+    router.use(Urls.CONFIRM_COMPANY, authenticate, ConfirmCompanyRouter);
+    router.use(Urls.PSC_TYPE, authenticate, PscTypeRouter);
+    router.use(Urls.INDIVIDUAL_PSC_LIST, authenticate, IndividualPscListRouter);
+    router.use(Urls.PERSONAL_CODE, authenticate, PersonalCodeRouter);
+    router.use(Urls.INDIVIDUAL_STATEMENT, authenticate, IndividualStatementRouter);
+    router.use(Urls.PSC_VERIFIED, authenticate, PscVerifiedRouter);
+    router.use(Urls.RLE_LIST, authenticate, RlePscListRouter);
+    router.use(Urls.RLE_DETAILS, authenticate, RleDetailsRouter);
+    router.use(Urls.RLE_DIRECTOR, authenticate, RleDirectorRouter);
 
     router.use("*", (req: Request, res: Response) => {
         res.status(404).render("partials/error_400");

--- a/test/authentication/authenicationCheck.unit.ts
+++ b/test/authentication/authenicationCheck.unit.ts
@@ -1,53 +1,35 @@
+import middlewareMocks from "../mocks/allMiddleware.mock";
 import request from "supertest";
 import app from ".../../../src/app";
 import { PrefixedUrls } from ".../../../src/constants";
-import middlewareMocks from "../mocks/allMiddleware.mock";
 
 jest.mock(".../../../src/services/companyProfileService");
 
-describe("Authenticated users only can access the PSC verification web pages except for the start page", () => {
+describe("Authentication checked on all pages except for the start page", () => {
 
     beforeEach(() => {
-        middlewareMocks.mockAuthenticationMiddleware.mockClear();
-        middlewareMocks.mockSessionMiddleware.mockClear();
+        jest.clearAllMocks();
     });
 
     afterEach(() => {
         expect(middlewareMocks.mockSessionMiddleware).toHaveBeenCalledTimes(1);
     });
 
-    it("Should not call the authentication middleware when navigating to the start page", async () => {
+    it(`Should not authenticate when navigating to '${PrefixedUrls.START}'`, async () => {
         const resp = await request(app).get(PrefixedUrls.START);
+
         expect(middlewareMocks.mockAuthenticationMiddleware).not.toHaveBeenCalled();
     });
 
-    it("Should call the authentication middleware once for the confirm company page", async () => {
-        const resp = await request(app).get(PrefixedUrls.CONFIRM_COMPANY);
-        expect(middlewareMocks.mockAuthenticationMiddleware).toHaveBeenCalledTimes(1);
-    });
-
-    it("Should call the authentication middleware once for the psc type page ", async () => {
-        const resp = await request(app).get(PrefixedUrls.PSC_TYPE);
-        expect(middlewareMocks.mockAuthenticationMiddleware).toHaveBeenCalledTimes(1);
-    });
-
-    it("Should call the authentication middleware once for the individual psc list page ", async () => {
-        const resp = await request(app).get(PrefixedUrls.INDIVIDUAL_PSC_LIST);
-        expect(middlewareMocks.mockAuthenticationMiddleware).toHaveBeenCalledTimes(1);
-    });
-
-    // TODO - test for the psc details page
-
-    it("Should call the authentication middleware once for the individual psc statement page ", async () => {
-        const resp = await request(app).get(PrefixedUrls.INDIVIDUAL_STATEMENT);
-        expect(middlewareMocks.mockAuthenticationMiddleware).toHaveBeenCalledTimes(1);
-    });
-
-    it("Should call the authentication middleware once for the psc verified page ", async () => {
-        const resp = await request(app).get(PrefixedUrls.PSC_VERIFIED);
-        expect(middlewareMocks.mockAuthenticationMiddleware).toHaveBeenCalledTimes(1);
-    });
-
     // TODO -  Add tests for the RLE journey pages
+    it.each([PrefixedUrls.CONFIRM_COMPANY,
+        PrefixedUrls.PSC_TYPE,
+        PrefixedUrls.INDIVIDUAL_PSC_LIST,
+        PrefixedUrls.INDIVIDUAL_STATEMENT,
+        PrefixedUrls.PSC_VERIFIED])("Should authenticate when navigating to '%s'", async (url) => {
+        const resp = await request(app).get(url);
+
+        expect(middlewareMocks.mockAuthenticationMiddleware).toHaveBeenCalledTimes(1);
+    });
 
 });

--- a/test/authentication/authenicationCheck.unit.ts
+++ b/test/authentication/authenicationCheck.unit.ts
@@ -1,0 +1,53 @@
+import request from "supertest";
+import app from ".../../../src/app";
+import { PrefixedUrls } from ".../../../src/constants";
+import middlewareMocks from "../mocks/allMiddleware.mock";
+
+jest.mock(".../../../src/services/companyProfileService");
+
+describe("Authenticated users only can access the PSC verification web pages except for the start page", () => {
+
+    beforeEach(() => {
+        middlewareMocks.mockAuthenticationMiddleware.mockClear();
+        middlewareMocks.mockSessionMiddleware.mockClear();
+    });
+
+    afterEach(() => {
+        expect(middlewareMocks.mockSessionMiddleware).toHaveBeenCalledTimes(1);
+    });
+
+    it("Should not call the authentication middleware when navigating to the start page", async () => {
+        const resp = await request(app).get(PrefixedUrls.START);
+        expect(middlewareMocks.mockAuthenticationMiddleware).not.toHaveBeenCalled();
+    });
+
+    it("Should call the authentication middleware once for the confirm company page", async () => {
+        const resp = await request(app).get(PrefixedUrls.CONFIRM_COMPANY);
+        expect(middlewareMocks.mockAuthenticationMiddleware).toHaveBeenCalledTimes(1);
+    });
+
+    it("Should call the authentication middleware once for the psc type page ", async () => {
+        const resp = await request(app).get(PrefixedUrls.PSC_TYPE);
+        expect(middlewareMocks.mockAuthenticationMiddleware).toHaveBeenCalledTimes(1);
+    });
+
+    it("Should call the authentication middleware once for the individual psc list page ", async () => {
+        const resp = await request(app).get(PrefixedUrls.INDIVIDUAL_PSC_LIST);
+        expect(middlewareMocks.mockAuthenticationMiddleware).toHaveBeenCalledTimes(1);
+    });
+
+    // TODO - test for the psc details page
+
+    it("Should call the authentication middleware once for the individual psc statement page ", async () => {
+        const resp = await request(app).get(PrefixedUrls.INDIVIDUAL_STATEMENT);
+        expect(middlewareMocks.mockAuthenticationMiddleware).toHaveBeenCalledTimes(1);
+    });
+
+    it("Should call the authentication middleware once for the psc verified page ", async () => {
+        const resp = await request(app).get(PrefixedUrls.PSC_VERIFIED);
+        expect(middlewareMocks.mockAuthenticationMiddleware).toHaveBeenCalledTimes(1);
+    });
+
+    // TODO -  Add tests for the RLE journey pages
+
+});

--- a/test/middleware/authentication.unit.ts
+++ b/test/middleware/authentication.unit.ts
@@ -1,0 +1,30 @@
+import { AuthOptions, authMiddleware } from "@companieshouse/web-security-node";
+import { NextFunction, Request, Response } from "express";
+import { authenticationMiddleware } from "../../src/middleware/authentication";
+
+jest.mock("@companieshouse/web-security-node");
+
+// get handle on mocked function
+const mockAuthenticationMiddleware = authMiddleware as jest.Mock;
+
+// tell the mock what to return
+mockAuthenticationMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next());
+
+describe("authenticationMiddleware", () => {
+
+    it("should use the correct URLs", () => {
+        const originalUrl = "originalUrl";
+        const req = { originalUrl } as Request;
+        const expectedConfig: AuthOptions = {
+            chsWebUrl: "",
+            returnUrl: originalUrl
+        };
+        const res = {} as Response;
+        const next = jest.fn();
+        authenticationMiddleware(req, res, next);
+
+        // wip
+        // expect(mockAuthenticationMiddleware).toHaveBeenCalled();
+        // expect(authMiddleware).toHaveBeenCalledWith(expectedConfig);
+    });
+});

--- a/test/mocks/authenticationMiddleware.mock.ts
+++ b/test/mocks/authenticationMiddleware.mock.ts
@@ -1,11 +1,11 @@
 import { Session } from "@companieshouse/node-session-handler";
 import { NextFunction, Request, Response } from "express";
-import { authenticationMiddleware } from "../../src/middleware/authentication";
+import { authenticate } from "../../src/middleware/authentication";
 
 jest.mock("../../src/middleware/authentication");
 
 // get handle on mocked function
-const mockAuthenticationMiddleware = authenticationMiddleware as jest.Mock;
+const mockAuthenticationMiddleware = authenticate as jest.Mock;
 
 export const session = new Session();
 

--- a/test/routers/handlers/confirm-company/confirmCompany.unit.ts
+++ b/test/routers/handlers/confirm-company/confirmCompany.unit.ts
@@ -1,8 +1,8 @@
+import middlewareMocks from "../../../mocks/allMiddleware.mock";
 import request from "supertest";
 import app from "../../../../src/app";
 import { PrefixedUrls } from "../../../../src/constants";
 import { getCompanyProfile } from "../../../../src/services/companyProfileService";
-import middlewareMocks from "../../../mocks/allMiddleware.mock";
 import { validCompanyProfile } from "../../../mocks/companyProfile.mock";
 
 jest.mock("../../../../src/services/companyProfileService");

--- a/test/routers/handlers/confirm-company/confirmCompany.unit.ts
+++ b/test/routers/handlers/confirm-company/confirmCompany.unit.ts
@@ -15,12 +15,10 @@ mockGetCompanyProfile.mockResolvedValue(validCompanyProfile);
 describe("confirm company tests", () => {
 
     beforeEach(() => {
-        middlewareMocks.mockAuthenticationMiddleware.mockClear();
         middlewareMocks.mockSessionMiddleware.mockClear();
     });
 
     afterEach(() => {
-        expect(middlewareMocks.mockAuthenticationMiddleware).toHaveBeenCalledTimes(1);
         expect(middlewareMocks.mockSessionMiddleware).toHaveBeenCalledTimes(1);
     });
 

--- a/test/routers/start.unit.ts
+++ b/test/routers/start.unit.ts
@@ -1,14 +1,27 @@
+import middlewareMocks from "../mocks/allMiddleware.mock";
 import request from "supertest";
 import app from "../../src/app";
-import { PrefixedUrls } from "../../src/constants";
-import middlewareMocks from "../mocks/allMiddleware.mock";
+import { PrefixedUrls, servicePathPrefix } from "../../src/constants";
+import { HttpStatusCode } from "axios";
 
 describe("start page tests", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
     const HEADING = "PSC Verification";
-    it("should render the start page", async () => {
+    it("should render the start page for service root", async () => {
+        const resp = await request(app).get(servicePathPrefix);
+
+        expect(resp.status).toBe(HttpStatusCode.Ok);
+        expect(resp.text).toContain(HEADING);
+        expect(middlewareMocks.mockSessionMiddleware).toHaveBeenCalledTimes(1);
+    });
+
+    it("should render the start page for Start", async () => {
         const resp = await request(app).get(PrefixedUrls.START);
 
-        expect(resp.status).toBe(200);
+        expect(resp.status).toBe(HttpStatusCode.Ok);
         expect(resp.text).toContain(HEADING);
         expect(middlewareMocks.mockSessionMiddleware).toHaveBeenCalledTimes(1);
     });


### PR DESCRIPTION
**Add new tests for the authentication middleware to maximise test coverage**
- new test for the authentication middleware
- authentication element relocated from `confirmCompany.unit.ts `into new test `authenticationCheck.unit.ts`, to test authentication across all pages
- `jest.config.js` updates to prevent mocking of all middleware and removal of redundant code
- authentication.ts - call to `authMiddleware` is split into two stages to improve clarification and ease of testing
-  references to authenticationMiddleware are renamed to authenticate for clarification

