### PR TITLE
Add PSC service to call getPscIndividual details

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "license": "MIT",
             "dependencies": {
-                "@companieshouse/api-sdk-node": "^2.0.157",
+                "@companieshouse/api-sdk-node": "^2.0.159",
                 "@companieshouse/ch-node-utils": "^1.2.0",
                 "@companieshouse/node-session-handler": "^5.0.1",
                 "@companieshouse/structured-logging-node": "^2.0.1",
@@ -78,15 +78,6 @@
                 "npm": "^10"
             }
         },
-        "node_modules/@aashutoshrathi/word-wrap": {
-            "version": "1.2.6",
-            "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
-            "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/@ampproject/remapping": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
@@ -123,21 +114,21 @@
             }
         },
         "node_modules/@babel/core": {
-            "version": "7.24.4",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.4.tgz",
-            "integrity": "sha512-MBVlMXP+kkl5394RBLSxxk/iLTeVGuXTV3cIDXavPpMMqnSnt6apKgan/U8O3USWZCWZT/TbgfEpKa4uMgN4Dg==",
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.5.tgz",
+            "integrity": "sha512-tVQRucExLQ02Boi4vdPp49svNGcfL2GhdTCT9aldhXgCJVAI21EtRfBettiuLUwce/7r6bFdgs6JFkcdTiFttA==",
             "dev": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
                 "@babel/code-frame": "^7.24.2",
-                "@babel/generator": "^7.24.4",
+                "@babel/generator": "^7.24.5",
                 "@babel/helper-compilation-targets": "^7.23.6",
-                "@babel/helper-module-transforms": "^7.23.3",
-                "@babel/helpers": "^7.24.4",
-                "@babel/parser": "^7.24.4",
+                "@babel/helper-module-transforms": "^7.24.5",
+                "@babel/helpers": "^7.24.5",
+                "@babel/parser": "^7.24.5",
                 "@babel/template": "^7.24.0",
-                "@babel/traverse": "^7.24.1",
-                "@babel/types": "^7.24.0",
+                "@babel/traverse": "^7.24.5",
+                "@babel/types": "^7.24.5",
                 "convert-source-map": "^2.0.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
@@ -162,12 +153,12 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.24.4",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.4.tgz",
-            "integrity": "sha512-Xd6+v6SnjWVx/nus+y0l1sxMOTOMBkyL4+BIdbALyatQnAe/SRVjANeDPSCYaX+i1iJmuGSKf3Z+E+V/va1Hvw==",
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.5.tgz",
+            "integrity": "sha512-x32i4hEXvr+iI0NEoEfDKzlemF8AmtOP8CcrRaEcpzysWuoEb1KknpcvMsHKPONoKZiDuItklgWhB18xEhr9PA==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.24.0",
+                "@babel/types": "^7.24.5",
                 "@jridgewell/gen-mapping": "^0.3.5",
                 "@jridgewell/trace-mapping": "^0.3.25",
                 "jsesc": "^2.5.1"
@@ -248,16 +239,16 @@
             }
         },
         "node_modules/@babel/helper-module-transforms": {
-            "version": "7.23.3",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.3.tgz",
-            "integrity": "sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==",
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.24.5.tgz",
+            "integrity": "sha512-9GxeY8c2d2mdQUP1Dye0ks3VDyIMS98kt/llQ2nUId8IsWqTF0l1LkSX0/uP7l7MCDrzXS009Hyhe2gzTiGW8A==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-environment-visitor": "^7.22.20",
-                "@babel/helper-module-imports": "^7.22.15",
-                "@babel/helper-simple-access": "^7.22.5",
-                "@babel/helper-split-export-declaration": "^7.22.6",
-                "@babel/helper-validator-identifier": "^7.22.20"
+                "@babel/helper-module-imports": "^7.24.3",
+                "@babel/helper-simple-access": "^7.24.5",
+                "@babel/helper-split-export-declaration": "^7.24.5",
+                "@babel/helper-validator-identifier": "^7.24.5"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -267,33 +258,33 @@
             }
         },
         "node_modules/@babel/helper-plugin-utils": {
-            "version": "7.24.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.0.tgz",
-            "integrity": "sha512-9cUznXMG0+FxRuJfvL82QlTqIzhVW9sL0KjMPHhAOOvpQGL8QtdxnBKILjBqxlHyliz0yCa1G903ZXI/FuHy2w==",
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.5.tgz",
+            "integrity": "sha512-xjNLDopRzW2o6ba0gKbkZq5YWEBaK3PCyTOY1K2P/O07LGMhMqlMXPxwN4S5/RhWuCobT8z0jrlKGlYmeR1OhQ==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-simple-access": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
-            "integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.24.5.tgz",
+            "integrity": "sha512-uH3Hmf5q5n7n8mz7arjUlDOCbttY/DW4DYhE6FUsjKJ/oYC1kQQUvwEQWxRwUpX9qQKRXeqLwWxrqilMrf32sQ==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.22.5"
+                "@babel/types": "^7.24.5"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-split-export-declaration": {
-            "version": "7.22.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
-            "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.5.tgz",
+            "integrity": "sha512-5CHncttXohrHk8GWOFCcCl4oRD9fKosWlIRgWm4ql9VYioKm52Mk2xsmoohvm7f3JoiLSM5ZgJuRaf5QZZYd3Q==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.22.5"
+                "@babel/types": "^7.24.5"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -309,9 +300,9 @@
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.22.20",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-            "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.5.tgz",
+            "integrity": "sha512-3q93SSKX2TWCG30M2G2kwaKeTYgEUp5Snjuj8qm729SObL6nbtUldAi37qbxkD5gg3xnBio+f9nqpSepGZMvxA==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
@@ -327,26 +318,26 @@
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.24.4",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.4.tgz",
-            "integrity": "sha512-FewdlZbSiwaVGlgT1DPANDuCHaDMiOo+D/IDYRFYjHOuv66xMSJ7fQwwODwRNAPkADIO/z1EoF/l2BCWlWABDw==",
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.5.tgz",
+            "integrity": "sha512-CiQmBMMpMQHwM5m01YnrM6imUG1ebgYJ+fAIW4FZe6m4qHTPaRHti+R8cggAwkdz4oXhtO4/K9JWlh+8hIfR2Q==",
             "dev": true,
             "dependencies": {
                 "@babel/template": "^7.24.0",
-                "@babel/traverse": "^7.24.1",
-                "@babel/types": "^7.24.0"
+                "@babel/traverse": "^7.24.5",
+                "@babel/types": "^7.24.5"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/highlight": {
-            "version": "7.24.2",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.2.tgz",
-            "integrity": "sha512-Yac1ao4flkTxTteCDZLEvdxg2fZfz1v8M4QpaGypq/WPDqg3ijHYbDfs+LG5hvzSoqaSZ9/Z9lKSP3CjZjv+pA==",
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.5.tgz",
+            "integrity": "sha512-8lLmua6AVh/8SLJRRVD6V8p73Hir9w5mJrhE+IPpILG31KKlI9iz5zmBYKcWPS59qSfgP9RaSBQSHHE81WKuEw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.22.20",
+                "@babel/helper-validator-identifier": "^7.24.5",
                 "chalk": "^2.4.2",
                 "js-tokens": "^4.0.0",
                 "picocolors": "^1.0.0"
@@ -427,9 +418,9 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.24.4",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.4.tgz",
-            "integrity": "sha512-zTvEBcghmeBma9QIGunWevvBAp4/Qu9Bdq+2k0Ot4fVMD6v3dsC9WOcRSKk7tRRyBM/53yKMJko9xOatGQAwSg==",
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.5.tgz",
+            "integrity": "sha512-EOv5IK8arwh3LI47dz1b0tKUb/1uhHAnHJOrjgtQMIpu1uXd9mlFrJg9IUgGUgZ41Ch0K8REPTYpO7B76b4vJg==",
             "dev": true,
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -616,9 +607,9 @@
             }
         },
         "node_modules/@babel/runtime": {
-            "version": "7.24.4",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.4.tgz",
-            "integrity": "sha512-dkxf7+hn8mFBwKjs9bvBlArzLVxVbS8usaPUDd5p2a9JCL9tB8OaOVN1isD4+Xyk4ns89/xeOmbQvgdK7IIVdA==",
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.5.tgz",
+            "integrity": "sha512-Nms86NXrsaeU9vbBJKni6gXiEXZ4CVpYVzEjDH9Sb8vmZ3UljyA1GSOJl/6LGPO8EHLuSF9H+IxNXHPX8QHJ4g==",
             "dependencies": {
                 "regenerator-runtime": "^0.14.0"
             },
@@ -641,19 +632,19 @@
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.1.tgz",
-            "integrity": "sha512-xuU6o9m68KeqZbQuDt2TcKSxUw/mrsvavlEqQ1leZ/B+C9tk6E4sRWy97WaXgvq5E+nU3cXMxv3WKOCanVMCmQ==",
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.5.tgz",
+            "integrity": "sha512-7aaBLeDQ4zYcUFDUD41lJc1fG8+5IU9DaNSJAgal866FGvmD5EbWQgnEC6kO1gGLsX0esNkfnJSndbTXA3r7UA==",
             "dev": true,
             "dependencies": {
-                "@babel/code-frame": "^7.24.1",
-                "@babel/generator": "^7.24.1",
+                "@babel/code-frame": "^7.24.2",
+                "@babel/generator": "^7.24.5",
                 "@babel/helper-environment-visitor": "^7.22.20",
                 "@babel/helper-function-name": "^7.23.0",
                 "@babel/helper-hoist-variables": "^7.22.5",
-                "@babel/helper-split-export-declaration": "^7.22.6",
-                "@babel/parser": "^7.24.1",
-                "@babel/types": "^7.24.0",
+                "@babel/helper-split-export-declaration": "^7.24.5",
+                "@babel/parser": "^7.24.5",
+                "@babel/types": "^7.24.5",
                 "debug": "^4.3.1",
                 "globals": "^11.1.0"
             },
@@ -671,13 +662,13 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.24.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.0.tgz",
-            "integrity": "sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==",
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.5.tgz",
+            "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-string-parser": "^7.23.4",
-                "@babel/helper-validator-identifier": "^7.22.20",
+                "@babel/helper-string-parser": "^7.24.1",
+                "@babel/helper-validator-identifier": "^7.24.5",
                 "to-fast-properties": "^2.0.0"
             },
             "engines": {
@@ -699,9 +690,9 @@
             }
         },
         "node_modules/@companieshouse/api-sdk-node": {
-            "version": "2.0.157",
-            "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.157.tgz",
-            "integrity": "sha512-5B+xzlPK0YyNcQoygk359HRmB7G0sw2PJwIFxrRm0yV92LsjVRgrVL+TABL95e5xrApoQ2vkLVwwdBNvYX07jQ==",
+            "version": "2.0.159",
+            "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.159.tgz",
+            "integrity": "sha512-6MWXdxoJcE93Sb2Y6qbokwd150P/Sp8ZadBr5bCNOoeGTue+f5Nm9vtmrnARa46Kv2PY6ZNgD3Oy4Qwtb+ATLw==",
             "dependencies": {
                 "axios": "^1.6.7",
                 "camelcase-keys": "~6.2.2",
@@ -1877,9 +1868,9 @@
             "dev": true
         },
         "node_modules/@types/superagent": {
-            "version": "8.1.6",
-            "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.6.tgz",
-            "integrity": "sha512-yzBOv+6meEHSzV2NThYYOA6RtqvPr3Hbob9ZLp3i07SH27CrYVfm8CrF7ydTmidtelsFiKx2I4gZAiAOamGgvQ==",
+            "version": "8.1.7",
+            "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.7.tgz",
+            "integrity": "sha512-NmIsd0Yj4DDhftfWvvAku482PZum4DBW7U51OvS8gvOkDDY0WT1jsVyDV3hK+vplrsYw8oDwi9QxOM7U68iwww==",
             "dependencies": {
                 "@types/cookiejar": "^2.1.5",
                 "@types/methods": "^1.1.4",
@@ -1922,16 +1913,16 @@
             "dev": true
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "7.7.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.7.1.tgz",
-            "integrity": "sha512-KwfdWXJBOviaBVhxO3p5TJiLpNuh2iyXyjmWN0f1nU87pwyvfS0EmjC6ukQVYVFJd/K1+0NWGPDXiyEyQorn0Q==",
+            "version": "7.8.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.8.0.tgz",
+            "integrity": "sha512-gFTT+ezJmkwutUPmB0skOj3GZJtlEGnlssems4AjkVweUPGj7jRwwqg0Hhg7++kPGJqKtTYx+R05Ftww372aIg==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/regexpp": "^4.10.0",
-                "@typescript-eslint/scope-manager": "7.7.1",
-                "@typescript-eslint/type-utils": "7.7.1",
-                "@typescript-eslint/utils": "7.7.1",
-                "@typescript-eslint/visitor-keys": "7.7.1",
+                "@typescript-eslint/scope-manager": "7.8.0",
+                "@typescript-eslint/type-utils": "7.8.0",
+                "@typescript-eslint/utils": "7.8.0",
+                "@typescript-eslint/visitor-keys": "7.8.0",
                 "debug": "^4.3.4",
                 "graphemer": "^1.4.0",
                 "ignore": "^5.3.1",
@@ -1957,15 +1948,15 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "7.7.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.7.1.tgz",
-            "integrity": "sha512-vmPzBOOtz48F6JAGVS/kZYk4EkXao6iGrD838sp1w3NQQC0W8ry/q641KU4PrG7AKNAf56NOcR8GOpH8l9FPCw==",
+            "version": "7.8.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.8.0.tgz",
+            "integrity": "sha512-KgKQly1pv0l4ltcftP59uQZCi4HUYswCLbTqVZEJu7uLX8CTLyswqMLqLN+2QFz4jCptqWVV4SB7vdxcH2+0kQ==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "7.7.1",
-                "@typescript-eslint/types": "7.7.1",
-                "@typescript-eslint/typescript-estree": "7.7.1",
-                "@typescript-eslint/visitor-keys": "7.7.1",
+                "@typescript-eslint/scope-manager": "7.8.0",
+                "@typescript-eslint/types": "7.8.0",
+                "@typescript-eslint/typescript-estree": "7.8.0",
+                "@typescript-eslint/visitor-keys": "7.8.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -1985,13 +1976,13 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "7.7.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.7.1.tgz",
-            "integrity": "sha512-PytBif2SF+9SpEUKynYn5g1RHFddJUcyynGpztX3l/ik7KmZEv19WCMhUBkHXPU9es/VWGD3/zg3wg90+Dh2rA==",
+            "version": "7.8.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.8.0.tgz",
+            "integrity": "sha512-viEmZ1LmwsGcnr85gIq+FCYI7nO90DVbE37/ll51hjv9aG+YZMb4WDE2fyWpUR4O/UrhGRpYXK/XajcGTk2B8g==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "7.7.1",
-                "@typescript-eslint/visitor-keys": "7.7.1"
+                "@typescript-eslint/types": "7.8.0",
+                "@typescript-eslint/visitor-keys": "7.8.0"
             },
             "engines": {
                 "node": "^18.18.0 || >=20.0.0"
@@ -2002,13 +1993,13 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "7.7.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.7.1.tgz",
-            "integrity": "sha512-ZksJLW3WF7o75zaBPScdW1Gbkwhd/lyeXGf1kQCxJaOeITscoSl0MjynVvCzuV5boUz/3fOI06Lz8La55mu29Q==",
+            "version": "7.8.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.8.0.tgz",
+            "integrity": "sha512-H70R3AefQDQpz9mGv13Uhi121FNMh+WEaRqcXTX09YEDky21km4dV1ZXJIp8QjXc4ZaVkXVdohvWDzbnbHDS+A==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "7.7.1",
-                "@typescript-eslint/utils": "7.7.1",
+                "@typescript-eslint/typescript-estree": "7.8.0",
+                "@typescript-eslint/utils": "7.8.0",
                 "debug": "^4.3.4",
                 "ts-api-utils": "^1.3.0"
             },
@@ -2029,9 +2020,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "7.7.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.7.1.tgz",
-            "integrity": "sha512-AmPmnGW1ZLTpWa+/2omPrPfR7BcbUU4oha5VIbSbS1a1Tv966bklvLNXxp3mrbc+P2j4MNOTfDffNsk4o0c6/w==",
+            "version": "7.8.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.8.0.tgz",
+            "integrity": "sha512-wf0peJ+ZGlcH+2ZS23aJbOv+ztjeeP8uQ9GgwMJGVLx/Nj9CJt17GWgWWoSmoRVKAX2X+7fzEnAjxdvK2gqCLw==",
             "dev": true,
             "engines": {
                 "node": "^18.18.0 || >=20.0.0"
@@ -2042,13 +2033,13 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "7.7.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.7.1.tgz",
-            "integrity": "sha512-CXe0JHCXru8Fa36dteXqmH2YxngKJjkQLjxzoj6LYwzZ7qZvgsLSc+eqItCrqIop8Vl2UKoAi0StVWu97FQZIQ==",
+            "version": "7.8.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.8.0.tgz",
+            "integrity": "sha512-5pfUCOwK5yjPaJQNy44prjCwtr981dO8Qo9J9PwYXZ0MosgAbfEMB008dJ5sNo3+/BN6ytBPuSvXUg9SAqB0dg==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "7.7.1",
-                "@typescript-eslint/visitor-keys": "7.7.1",
+                "@typescript-eslint/types": "7.8.0",
+                "@typescript-eslint/visitor-keys": "7.8.0",
                 "debug": "^4.3.4",
                 "globby": "^11.1.0",
                 "is-glob": "^4.0.3",
@@ -2070,17 +2061,17 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "7.7.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.7.1.tgz",
-            "integrity": "sha512-QUvBxPEaBXf41ZBbaidKICgVL8Hin0p6prQDu6bbetWo39BKbWJxRsErOzMNT1rXvTll+J7ChrbmMCXM9rsvOQ==",
+            "version": "7.8.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.8.0.tgz",
+            "integrity": "sha512-L0yFqOCflVqXxiZyXrDr80lnahQfSOfc9ELAAZ75sqicqp2i36kEZZGuUymHNFoYOqxRT05up760b4iGsl02nQ==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.4.0",
                 "@types/json-schema": "^7.0.15",
                 "@types/semver": "^7.5.8",
-                "@typescript-eslint/scope-manager": "7.7.1",
-                "@typescript-eslint/types": "7.7.1",
-                "@typescript-eslint/typescript-estree": "7.7.1",
+                "@typescript-eslint/scope-manager": "7.8.0",
+                "@typescript-eslint/types": "7.8.0",
+                "@typescript-eslint/typescript-estree": "7.8.0",
                 "semver": "^7.6.0"
             },
             "engines": {
@@ -2095,12 +2086,12 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "7.7.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.7.1.tgz",
-            "integrity": "sha512-gBL3Eq25uADw1LQ9kVpf3hRM+DWzs0uZknHYK3hq4jcTPqVCClHGDnB6UUUV2SFeBeA4KWHWbbLqmbGcZ4FYbw==",
+            "version": "7.8.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.8.0.tgz",
+            "integrity": "sha512-q4/gibTNBQNA0lGyYQCmWRS5D15n8rXh4QjK3KV+MBPlTYHpfBUT3D3PaPR/HeNiI9W6R7FvlkcGhNyAoP+caA==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "7.7.1",
+                "@typescript-eslint/types": "7.8.0",
                 "eslint-visitor-keys": "^3.4.3"
             },
             "engines": {
@@ -3394,9 +3385,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001612",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001612.tgz",
-            "integrity": "sha512-lFgnZ07UhaCcsSZgWW0K5j4e69dK1u/ltrL9lTUiFOwNHs12S3UMIEYgBV0Z6C6hRDev7iRnMzzYmKabYdXF9g==",
+            "version": "1.0.30001616",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001616.tgz",
+            "integrity": "sha512-RHVYKov7IcdNjVHJFNY/78RdG4oGVjbayxv8u5IO74Wv7Hlq4PnJE6mo/OjFijjVFNy5ijnCt6H3IIo4t+wfEw==",
             "dev": true,
             "funding": [
                 {
@@ -3523,9 +3514,9 @@
             "dev": true
         },
         "node_modules/cjs-module-lexer": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
-            "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.3.1.tgz",
+            "integrity": "sha512-a3KdPAANPbNE4ZUv9h6LckSl9zLsYOP4MBmhIPkRaeyybt+r4UghLvq+xw/YwUcC1gqylCkL4rdVs3Lwupjm4Q==",
             "dev": true
         },
         "node_modules/class-utils": {
@@ -4520,9 +4511,9 @@
             "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.748",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.748.tgz",
-            "integrity": "sha512-VWqjOlPZn70UZ8FTKUOkUvBLeTQ0xpty66qV0yJcAGY2/CthI4xyW9aEozRVtuwv3Kpf5xTesmJUcPwuJmgP4A==",
+            "version": "1.4.757",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.757.tgz",
+            "integrity": "sha512-jftDaCknYSSt/+KKeXzH3LX5E2CvRLm75P3Hj+J/dv3CL0qUYcOt13d5FN1NiL5IJbbhzHrb3BomeG2tkSlZmw==",
             "dev": true
         },
         "node_modules/emittery": {
@@ -5106,9 +5097,9 @@
             }
         },
         "node_modules/eslint-plugin-unused-imports": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-3.1.0.tgz",
-            "integrity": "sha512-9l1YFCzXKkw1qtAru1RWUtG2EVDZY0a0eChKXcL+EZ5jitG7qxdctu4RnvhOJHv4xfmUf7h+JJPINlVpGhZMrw==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-3.2.0.tgz",
+            "integrity": "sha512-6uXyn6xdINEpxE1MtDjxQsyXB37lfyO2yKGVVgtD7WEWQGORSOZjgrD6hBhvGv4/SO+TOlS+UnC6JppRqbuwGQ==",
             "dev": true,
             "dependencies": {
                 "eslint-rule-composer": "^0.3.0"
@@ -6605,12 +6596,13 @@
             }
         },
         "node_modules/globalthis": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
-            "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+            "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
             "dev": true,
             "dependencies": {
-                "define-properties": "^1.1.3"
+                "define-properties": "^1.2.1",
+                "gopd": "^1.0.1"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -7336,9 +7328,9 @@
             }
         },
         "node_modules/i18next": {
-            "version": "23.11.2",
-            "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.11.2.tgz",
-            "integrity": "sha512-qMBm7+qT8jdpmmDw/kQD16VpmkL9BdL+XNAK5MNbNFaf1iQQq35ZbPrSlqmnNPOSUY4m342+c0t0evinF5l7sA==",
+            "version": "23.11.3",
+            "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.11.3.tgz",
+            "integrity": "sha512-Pq/aSKowir7JM0rj+Wa23Kb6KKDUGno/HjG+wRQu0PxoTbpQ4N89MAT0rFGvXmLkRLNMb1BbBOKGozl01dabzg==",
             "funding": [
                 {
                     "type": "individual",
@@ -10627,17 +10619,17 @@
             }
         },
         "node_modules/optionator": {
-            "version": "0.9.3",
-            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
-            "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
+            "version": "0.9.4",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+            "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
             "dev": true,
             "dependencies": {
-                "@aashutoshrathi/word-wrap": "^1.2.3",
                 "deep-is": "^0.1.3",
                 "fast-levenshtein": "^2.0.6",
                 "levn": "^0.4.1",
                 "prelude-ls": "^1.2.1",
-                "type-check": "^0.4.0"
+                "type-check": "^0.4.0",
+                "word-wrap": "^1.2.5"
             },
             "engines": {
                 "node": ">= 0.8.0"
@@ -11282,9 +11274,9 @@
             }
         },
         "node_modules/react-is": {
-            "version": "18.2.0",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-            "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+            "version": "18.3.1",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+            "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
             "dev": true
         },
         "node_modules/read-pkg": {
@@ -12072,14 +12064,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/shell-quote": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.1.tgz",
-            "integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==",
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/side-channel": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
@@ -12303,19 +12287,18 @@
             }
         },
         "node_modules/sonarqube-scanner": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/sonarqube-scanner/-/sonarqube-scanner-3.4.0.tgz",
-            "integrity": "sha512-2B/IgA2CkTg8GPKlkqxSPuWLlcEZcoRxWkcZYr47f8Ni1YOEbCS/EUl9/bn68sanZ0lee5adRPuQpGj0EiEW2A==",
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/sonarqube-scanner/-/sonarqube-scanner-3.5.0.tgz",
+            "integrity": "sha512-MiIJhFv8p/ePlTO0A1uC6UOxfIjSnjEw3sZ1G8q9mt6y2W/q/QrE/XWo0zCKkS8flmX0T2fjEuaDHnS/P9QQmw==",
             "dependencies": {
-                "adm-zip": "^0.5.10",
-                "fancy-log": "^2.0.0",
-                "https-proxy-agent": "^7.0.1",
-                "jest-sonar-reporter": "^2.0.0",
-                "mkdirp": "^3.0.1",
-                "node-downloader-helper": "^2.1.9",
-                "progress": "^2.0.3",
-                "shell-quote": "^1.8.1",
-                "slugify": "^1.6.6"
+                "adm-zip": "0.5.12",
+                "fancy-log": "2.0.0",
+                "https-proxy-agent": "7.0.4",
+                "jest-sonar-reporter": "2.0.0",
+                "mkdirp": "3.0.1",
+                "node-downloader-helper": "2.1.9",
+                "progress": "2.0.3",
+                "slugify": "1.6.6"
             },
             "bin": {
                 "sonar-scanner": "src/bin/sonar-scanner"
@@ -13468,9 +13451,9 @@
             }
         },
         "node_modules/update-browserslist-db": {
-            "version": "1.0.13",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
-            "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
+            "version": "1.0.15",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.15.tgz",
+            "integrity": "sha512-K9HWH62x3/EalU1U6sjSZiylm9C8tgq2mSvshZpqc7QE69RaA2qjhkW2HlNA0tFpEbtyFz7HTqbSdN4MSwUodA==",
             "dev": true,
             "funding": [
                 {
@@ -13487,7 +13470,7 @@
                 }
             ],
             "dependencies": {
-                "escalade": "^3.1.1",
+                "escalade": "^3.1.2",
                 "picocolors": "^1.0.0"
             },
             "bin": {
@@ -13846,6 +13829,15 @@
             },
             "engines": {
                 "node": ">= 6"
+            }
+        },
+        "node_modules/word-wrap": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+            "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/workerpool": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "author": "Moses Wejuli <mwejuli@companieshouse.gov.uk>",
     "license": "MIT",
     "dependencies": {
-        "@companieshouse/api-sdk-node": "^2.0.157",
+        "@companieshouse/api-sdk-node": "^2.0.159",
         "@companieshouse/ch-node-utils": "^1.2.0",
         "@companieshouse/node-session-handler": "^5.0.1",
         "@companieshouse/structured-logging-node": "^2.0.1",

--- a/src/routers/confirmCompanyRouter.ts
+++ b/src/routers/confirmCompanyRouter.ts
@@ -26,7 +26,9 @@ router.post(Urls.CONFIRM_COMPANY, authenticate, handleExceptions(async (req: Req
 
     const number = req.query.companyNumber as string;
     const verification: PscVerification = {
-        company_number: number
+        company_number: number,
+        // TODO hardcoded value, remove when PSC Id is selected from the List screen
+        psc_appointment_id: "1kdaTltWeaP1EB70SSD9SLmiK5Y"
     };
     const resource = await createPscVerification(req, transaction, verification);
     logger.info("CREATED" + resource?.resource?.links.self);

--- a/src/services/pscService.ts
+++ b/src/services/pscService.ts
@@ -1,0 +1,28 @@
+import { Resource } from "@companieshouse/api-sdk-node";
+import ApiClient from "@companieshouse/api-sdk-node/dist/client";
+import { PersonWithSignificantControlResource } from "@companieshouse/api-sdk-node/dist/services/psc/types";
+import { ApiErrorResponse } from "@companieshouse/api-sdk-node/dist/services/resource";
+import { HttpStatusCode } from "axios";
+import { Request } from "express";
+import { createAndLogError, logger } from "../lib/logger";
+import { createOAuthApiClient } from "./apiClientService";
+
+export const getPscIndividual = async (request: Request, companyNumber: string, pscId: string): Promise<Resource<PersonWithSignificantControlResource>> => {
+    const oAuthApiClient: ApiClient = createOAuthApiClient(request.session);
+
+    logger.debug(`getPscIndividual for PSC Id ${pscId}`);
+    const sdkResponse: Resource<PersonWithSignificantControlResource> | ApiErrorResponse = await oAuthApiClient.pscService.getPscIndividual(companyNumber, pscId);
+
+    if (!sdkResponse || !sdkResponse.httpStatusCode || sdkResponse.httpStatusCode !== HttpStatusCode.Ok) {
+        throw createAndLogError(`getPscIndividual - Failed to get details for PSC Id  ${pscId}`);
+    }
+
+    logger.debug(`getPscIndividual response PSC ${JSON.stringify(sdkResponse)}`);
+    const PscSdkResponse = sdkResponse as Resource<PersonWithSignificantControlResource>;
+
+    if (!PscSdkResponse.resource) {
+        throw createAndLogError(`getPscIndividual returned no resource for PSC Id ${pscId}`);
+    }
+
+    return PscSdkResponse;
+};

--- a/test/mocks/Psc.mock.ts
+++ b/test/mocks/Psc.mock.ts
@@ -1,0 +1,30 @@
+import { PersonWithSignificantControlResource } from "@companieshouse/api-sdk-node/dist/services/psc/types";
+
+export const COMPANY_NUMBER = "12345678";
+export const PSC_ID = "67edfE436y35hetsie6zuAZtr";
+
+export const PSC_INDIVIDUAL: PersonWithSignificantControlResource = {
+    natures_of_control: ["ownership-of-shares-75-to-100-percent", "voting-rights-75-to-100-percent-as-trust"],
+    kind: "individual-person-with-significant-control",
+    name: "Sir Forename Middlename Surname",
+    name_elements: {
+        title: "Sir",
+        forename: "Forename",
+        middle_name: "Middlename",
+        surname: "Surname"
+    },
+    nationality: "British",
+    address: {
+        postal_code: "CF14 3UZ",
+        locality: "Cardiff",
+        region: "South Glamorgan",
+        address_line_1: "Crown Way"
+    },
+    country_of_residence: "Wales",
+    links: {
+        self: `/company/${COMPANY_NUMBER}/persons-with-significant-control/individual/${PSC_ID}`
+    },
+    date_of_birth: { year: "2000", month: "04" },
+    etag: "",
+    notified_on: ""
+};

--- a/test/services/pscService.unit.ts
+++ b/test/services/pscService.unit.ts
@@ -1,0 +1,73 @@
+import { PersonWithSignificantControlResource } from "@companieshouse/api-sdk-node/dist/services/psc/types";
+import { ApiResponse } from "@companieshouse/api-sdk-node/dist/services/resource";
+import { Session } from "@companieshouse/node-session-handler";
+import { HttpStatusCode } from "axios";
+import { Request } from "express";
+import { createOAuthApiClient } from "../../src/services/apiClientService";
+import { getPscIndividual } from "../../src/services/pscService";
+import { COMPANY_NUMBER, PSC_ID, PSC_INDIVIDUAL } from "../mocks/psc.mock";
+
+jest.mock("@companieshouse/api-sdk-node");
+jest.mock("../../src/services/apiClientService");
+
+const mockGetPscIndividual = jest.fn();
+const mockCreateOAuthApiClient = createOAuthApiClient as jest.Mock;
+let session: Session;
+
+mockCreateOAuthApiClient.mockReturnValue({
+    pscService: {
+        getPscIndividual: mockGetPscIndividual
+    }
+});
+
+describe("pscServiceIndividual", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        session = new Session();
+    });
+    it("getPscIndividual should return 200 OK HttpStatus response", async () => {
+        const mockResponse: ApiResponse<PersonWithSignificantControlResource> = {
+            httpStatusCode: HttpStatusCode.Ok,
+            resource: PSC_INDIVIDUAL
+        };
+        mockGetPscIndividual.mockResolvedValueOnce(mockResponse as ApiResponse<PersonWithSignificantControlResource>);
+        const request = {} as Request;
+
+        const response = await getPscIndividual(request, COMPANY_NUMBER, PSC_ID);
+
+        const resource = response.resource as PersonWithSignificantControlResource;
+        expect(response.httpStatusCode).toBe(HttpStatusCode.Ok);
+        expect(resource).toEqual(PSC_INDIVIDUAL);
+        expect(mockCreateOAuthApiClient).toHaveBeenCalledTimes(1);
+        expect(mockGetPscIndividual).toHaveBeenCalledTimes(1);
+        expect(mockGetPscIndividual).toHaveBeenCalledWith(COMPANY_NUMBER, PSC_ID);
+
+    });
+    it("getPscIndividual should throw an error if HttpStatus is not 200 OK", async () => {
+        const mockResponse: ApiResponse<PersonWithSignificantControlResource> = {
+            httpStatusCode: HttpStatusCode.ServiceUnavailable
+        };
+        mockGetPscIndividual.mockResolvedValueOnce(mockResponse as ApiResponse<PersonWithSignificantControlResource>);
+        const request = {} as Request;
+
+        try {
+            const response = await getPscIndividual(request, COMPANY_NUMBER, PSC_ID);
+            throw new Error("invalid expecting getPscIndividual to throw error");
+        } catch (error: any) {
+            expect(error.message).toBe("getPscIndividual - Failed to get details for PSC Id  67edfE436y35hetsie6zuAZtr");
+        }
+    });
+    it("getPscIndividual should throw an error if no resource is returned", async () => {
+        const mockResponse: ApiResponse<PersonWithSignificantControlResource> = {
+            httpStatusCode: HttpStatusCode.Ok
+        };
+        mockGetPscIndividual.mockResolvedValueOnce(mockResponse as ApiResponse<PersonWithSignificantControlResource>);
+        const request = {} as Request;
+        try {
+            await getPscIndividual(request, COMPANY_NUMBER, PSC_ID);
+            throw new Error("invalid expecting getPscIndividual to throw error");
+        } catch (error: any) {
+            expect(error.message).toBe("getPscIndividual returned no resource for PSC Id 67edfE436y35hetsie6zuAZtr");
+        }
+    });
+});


### PR DESCRIPTION
- in the confirmCompany Router I've hard coded a value for a PSC individual in our Docker `company_pscs` collection, that can then be retrieved with this new service
- the service can be called with `const pscDetailsResponse = await getPscIndividual(req, "00006400", "1kdaTltWeaP1EB70SSD9SLmiK5Y");`

IDVA3-1491