### PR TITLE
Move data fetches to middleware

### DIFF
--- a/src/middleware/authentication.ts
+++ b/src/middleware/authentication.ts
@@ -10,5 +10,4 @@ export const authenticate = (req: Request, res: Response, next: NextFunction) =>
 
     const authHandler = authMiddleware(authMiddlewareConfig);
     authHandler(req, res, next);
-    next();
 };

--- a/src/middleware/authentication.ts
+++ b/src/middleware/authentication.ts
@@ -10,5 +10,5 @@ export const authenticate = (req: Request, res: Response, next: NextFunction) =>
 
     const authHandler = authMiddleware(authMiddlewareConfig);
     authHandler(req, res, next);
-
+    next();
 };

--- a/src/middleware/fetchCompany.ts
+++ b/src/middleware/fetchCompany.ts
@@ -1,0 +1,19 @@
+import { NextFunction, Request, Response } from "express";
+import { logger } from "../lib/logger";
+import { CompanyProfile } from "@companieshouse/api-sdk-node/dist/services/company-profile/types";
+import { getCompanyProfile } from "../services/companyProfileService";
+
+export const fetchCompany = async (req: Request, res: Response, next: NextFunction) => {
+    const companyNumber = res.locals.submission?.data?.company_number;
+
+    if (companyNumber) {
+        logger.debug(`Retrieving company profile for company number ${companyNumber} ...`);
+
+        const response: CompanyProfile = await getCompanyProfile(req, companyNumber);
+        // store the profile in the request.locals (per express SOP)
+        res.locals.companyProfile = response;
+    } else {
+        logger.error("Cannot retrieve company profile: No company number found in submission resource");
+    }
+    next();
+};

--- a/src/middleware/fetchVerification.ts
+++ b/src/middleware/fetchVerification.ts
@@ -9,7 +9,7 @@ export const fetchVerification = async (req: Request, res: Response, next: NextF
     if (transactionId && resourceId) {
         logger.debug(`Retrieving verification resourceID ${resourceId} ...`);
 
-        const response = await getPscVerification(req, transactionId, req.params.submissionId);
+        const response = await getPscVerification(req, transactionId, resourceId);
         // store the submission in the request.locals (per express SOP)
         res.locals.submission = response.resource;
     } else {

--- a/src/middleware/fetchVerification.ts
+++ b/src/middleware/fetchVerification.ts
@@ -1,0 +1,19 @@
+import { NextFunction, Request, Response } from "express";
+import { logger } from "../lib/logger";
+import { getPscVerification } from "../services/pscVerificationService";
+
+export const fetchVerification = async (req: Request, res: Response, next: NextFunction) => {
+    const resourceId = req.params.submissionId;
+    const transactionId = req.params.transactionId;
+
+    if (transactionId && resourceId) {
+        logger.debug(`Retrieving verification resourceID ${resourceId} ...`);
+
+        const response = await getPscVerification(req, transactionId, req.params.submissionId);
+        // store the submission in the request.locals (per express SOP)
+        res.locals.submission = response.resource;
+    } else {
+        logger.error("No transactionId or submissionId found in request path parameters");
+    }
+    next();
+};

--- a/src/routerDispatch.ts
+++ b/src/routerDispatch.ts
@@ -4,6 +4,7 @@ import { Urls, servicePathPrefix } from "./constants";
 import { CompanyNumberRouter, ConfirmCompanyRouter, ConfirmRoStatementsRouter, IndividualPscListRouter, IndividualStatementRouter, NotADirectorRouter, PersonalCodeRouter, PscTypeRouter, PscVerifiedRouter, RleDetailsRouter, RleDirectorRouter, RlePscListRouter, RleVerifiedRouter, StartRouter } from "./routers/utils";
 import { authenticate } from "./middleware/authentication";
 import { fetchVerification } from "./middleware/fetchVerification";
+import { fetchCompany } from "./middleware/fetchCompany";
 
 const routerDispatch = (app: Application) => {
 
@@ -16,7 +17,7 @@ const routerDispatch = (app: Application) => {
     router.use(Urls.COMPANY_NUMBER, authenticate, CompanyNumberRouter);
     router.use(Urls.CONFIRM_COMPANY, authenticate, ConfirmCompanyRouter);
     router.use(Urls.PSC_TYPE, authenticate, PscTypeRouter);
-    router.use(Urls.INDIVIDUAL_PSC_LIST, authenticate, fetchVerification, IndividualPscListRouter);
+    router.use(Urls.INDIVIDUAL_PSC_LIST, authenticate, fetchVerification, fetchCompany, IndividualPscListRouter);
     router.use(Urls.PERSONAL_CODE, authenticate, fetchVerification, PersonalCodeRouter);
     router.use(Urls.INDIVIDUAL_STATEMENT, authenticate, fetchVerification, IndividualStatementRouter);
     router.use(Urls.PSC_VERIFIED, authenticate, PscVerifiedRouter);

--- a/src/routerDispatch.ts
+++ b/src/routerDispatch.ts
@@ -2,6 +2,8 @@
 import { Application, Request, Response, Router } from "express";
 import { Urls, servicePathPrefix } from "./constants";
 import { CompanyNumberRouter, ConfirmCompanyRouter, ConfirmRoStatementsRouter, IndividualPscListRouter, IndividualStatementRouter, NotADirectorRouter, PersonalCodeRouter, PscTypeRouter, PscVerifiedRouter, RleDetailsRouter, RleDirectorRouter, RlePscListRouter, RleVerifiedRouter, StartRouter } from "./routers/utils";
+import { authenticate } from "./middleware/authentication";
+import { fetchVerification } from "./middleware/fetchVerification";
 
 const routerDispatch = (app: Application) => {
 
@@ -11,19 +13,19 @@ const routerDispatch = (app: Application) => {
 
     router.use("/", StartRouter);
     router.use(Urls.START, StartRouter);
-    router.use(CompanyNumberRouter);
-    router.use(IndividualPscListRouter);
-    router.use(PscTypeRouter);
-    router.use(ConfirmCompanyRouter);
-    router.use(PersonalCodeRouter);
-    router.use(IndividualStatementRouter);
-    router.use(PscVerifiedRouter);
-    router.use(RlePscListRouter);
-    router.use(RleDetailsRouter);
-    router.use(RleDirectorRouter);
-    router.use(ConfirmRoStatementsRouter);
-    router.use(NotADirectorRouter);
-    router.use(RleVerifiedRouter);
+    router.use(Urls.COMPANY_NUMBER, authenticate, CompanyNumberRouter);
+    router.use(Urls.CONFIRM_COMPANY, authenticate, ConfirmCompanyRouter);
+    router.use(Urls.PSC_TYPE, authenticate, PscTypeRouter);
+    router.use(Urls.INDIVIDUAL_PSC_LIST, authenticate, fetchVerification, IndividualPscListRouter);
+    router.use(Urls.PERSONAL_CODE, authenticate, fetchVerification, PersonalCodeRouter);
+    router.use(Urls.INDIVIDUAL_STATEMENT, authenticate, fetchVerification, IndividualStatementRouter);
+    router.use(Urls.PSC_VERIFIED, authenticate, PscVerifiedRouter);
+    router.use(Urls.RLE_LIST, authenticate, RlePscListRouter);
+    router.use(Urls.RLE_DETAILS, authenticate, RleDetailsRouter);
+    router.use(Urls.RLE_DIRECTOR, authenticate, RleDirectorRouter);
+    router.use(Urls.CONFIRM_RO_STATEMENTS, authenticate, ConfirmRoStatementsRouter);
+    router.use(Urls.NOT_A_DIRECTOR, authenticate, NotADirectorRouter);
+    router.use(Urls.RLE_VERIFIED, authenticate, RleVerifiedRouter);
 
     router.use("*", (req: Request, res: Response) => {
         res.status(404).render("partials/error_400");

--- a/src/routerDispatch.ts
+++ b/src/routerDispatch.ts
@@ -20,7 +20,7 @@ const routerDispatch = (app: Application) => {
     router.use(Urls.INDIVIDUAL_PSC_LIST, authenticate, fetchVerification, fetchCompany, IndividualPscListRouter);
     router.use(Urls.PERSONAL_CODE, authenticate, fetchVerification, PersonalCodeRouter);
     router.use(Urls.INDIVIDUAL_STATEMENT, authenticate, fetchVerification, IndividualStatementRouter);
-    router.use(Urls.PSC_VERIFIED, authenticate, PscVerifiedRouter);
+    router.use(Urls.PSC_VERIFIED, authenticate, fetchVerification, fetchCompany, PscVerifiedRouter);
     router.use(Urls.RLE_LIST, authenticate, RlePscListRouter);
     router.use(Urls.RLE_DETAILS, authenticate, RleDetailsRouter);
     router.use(Urls.RLE_DIRECTOR, authenticate, RleDirectorRouter);

--- a/src/routers/companyNumberRouter.ts
+++ b/src/routers/companyNumberRouter.ts
@@ -1,13 +1,12 @@
 import { NextFunction, Request, Response, Router } from "express";
-import { Urls } from "../constants";
-import { authenticate } from "../middleware/authentication";
 import { handleExceptions } from "../utils/asyncHandler";
 import { CompanyNumberHandler } from "./handlers/confirm-company/companyNumber";
-const router: Router = Router();
 
-router.get(Urls.COMPANY_NUMBER, authenticate, handleExceptions(async (req: Request, res: Response, _next: NextFunction) => {
+const router: Router = Router({ mergeParams: true });
+
+router.get("/", handleExceptions(async (req: Request, res: Response, _next: NextFunction) => {
     const handler = new CompanyNumberHandler();
-    await handler.execute(req, res);
+    handler.execute(req, res);
 }));
 
 export default router;

--- a/src/routers/confirmCompanyRouter.ts
+++ b/src/routers/confirmCompanyRouter.ts
@@ -1,7 +1,7 @@
 import { PscVerification } from "@companieshouse/api-sdk-node/dist/services/psc-verification-link/types";
 import { Transaction } from "@companieshouse/api-sdk-node/dist/services/transaction/types";
 import { NextFunction, Request, Response, Router } from "express";
-import { PrefixedUrls, SessionKeys, Urls } from "../constants";
+import { PrefixedUrls, SessionKeys } from "../constants";
 import { logger } from "../lib/logger";
 import { createPscVerification } from "../services/pscVerificationService";
 import { postTransaction } from "../services/transactionService";
@@ -10,17 +10,16 @@ import { selectLang } from "../utils/localise";
 import { addSearchParams } from "../utils/queryParams";
 import { getUrlWithTransactionIdAndSubmissionId } from "../utils/url";
 import { ConfirmCompanyHandler } from "./handlers/confirm-company/confirmCompany";
-import { authenticate } from "../middleware/authentication";
 
-const router: Router = Router();
+const router: Router = Router({ mergeParams: true });
 
-router.get(Urls.CONFIRM_COMPANY, authenticate, handleExceptions(async (req: Request, res: Response, _next: NextFunction) => {
+router.get("/", handleExceptions(async (req: Request, res: Response, _next: NextFunction) => {
     const handler = new ConfirmCompanyHandler();
     const { templatePath, viewData } = await handler.executeGet(req, res);
     res.render(templatePath, viewData);
 }));
 
-router.post(Urls.CONFIRM_COMPANY, authenticate, handleExceptions(async (req: Request, res: Response, _next: NextFunction) => {
+router.post("/", handleExceptions(async (req: Request, res: Response, _next: NextFunction) => {
 
     const transaction: Transaction = await postTransaction(req);
 

--- a/src/routers/confirmRoStatementsRouter.ts
+++ b/src/routers/confirmRoStatementsRouter.ts
@@ -1,11 +1,10 @@
 import { Request, Response, Router } from "express";
-import { Urls } from "../constants";
-import { authenticate } from "../middleware/authentication";
 import { handleExceptions } from "../utils/asyncHandler";
 import { ConfirmRoStatementsHandler } from "./handlers/confirm-ro-statements/confirmRoStatements";
-const router: Router = Router();
 
-router.get(Urls.CONFIRM_RO_STATEMENTS, authenticate, handleExceptions(async (req: Request, res: Response) => {
+const router: Router = Router({ mergeParams: true });
+
+router.get("/", handleExceptions(async (req: Request, res: Response) => {
     const handler = new ConfirmRoStatementsHandler();
     const { templatePath, viewData } = await handler.executeGet(req, res);
     res.render(templatePath, viewData);

--- a/src/routers/handlers/confirm-company/confirmCompany.ts
+++ b/src/routers/handlers/confirm-company/confirmCompany.ts
@@ -17,9 +17,9 @@ export class ConfirmCompanyHandler extends GenericHandler<ConfirmCompanyViewData
 
     private static templatePath = "router_views/confirmCompany/confirmCompany";
 
-    public async getViewData (req: Request): Promise<ConfirmCompanyViewData> {
+    public async getViewData (req: Request, res: Response): Promise<ConfirmCompanyViewData> {
 
-        const baseViewData = await super.getViewData(req);
+        const baseViewData = await super.getViewData(req, res);
         const lang = selectLang(req.query.lang);
         const locales = getLocalesService();
         const companyNumber = req.query.companyNumber as string;
@@ -43,10 +43,10 @@ export class ConfirmCompanyHandler extends GenericHandler<ConfirmCompanyViewData
         };
     }
 
-    public async executeGet (req: Request, _response: Response): Promise<ViewModel<ConfirmCompanyViewData>> {
+    public async executeGet (req: Request, res: Response): Promise<ViewModel<ConfirmCompanyViewData>> {
         logger.info(`ConfirmCompanyHandler execute called`);
 
-        const viewData = await this.getViewData(req);
+        const viewData = await this.getViewData(req, res);
 
         return {
             templatePath: ConfirmCompanyHandler.templatePath,

--- a/src/routers/handlers/confirm-ro-statements/confirmRoStatements.ts
+++ b/src/routers/handlers/confirm-ro-statements/confirmRoStatements.ts
@@ -16,9 +16,9 @@ export class ConfirmRoStatementsHandler extends GenericHandler<RleListViewData> 
 
     private static templatePath = "router_views/confirmRoStatements/confirmRoStatements";
 
-    public async getViewData (req: Request): Promise<RleListViewData> {
+    public async getViewData (req: Request, res: Response): Promise<RleListViewData> {
 
-        const baseViewData = await super.getViewData(req);
+        const baseViewData = await super.getViewData(req, res);
 
         const lang = selectLang(req.query.lang);
         const locales = getLocalesService();
@@ -32,12 +32,9 @@ export class ConfirmRoStatementsHandler extends GenericHandler<RleListViewData> 
         };
     }
 
-    public async executeGet (
-        req: Request,
-        _response: Response
-    ): Promise<ViewModel<RleListViewData>> {
+    public async executeGet (req: Request, res: Response): Promise<ViewModel<RleListViewData>> {
         logger.info(`ConfirmRoStatementsHandler execute called`);
-        const viewData = await this.getViewData(req);
+        const viewData = await this.getViewData(req, res);
 
         return {
             templatePath: ConfirmRoStatementsHandler.templatePath,

--- a/src/routers/handlers/generic.ts
+++ b/src/routers/handlers/generic.ts
@@ -1,7 +1,7 @@
 // Generic handler is the base handler that is extended by all other handlers
 // It contains methods that are common to multiple route handlers
 
-import { Request } from "express";
+import { Request, Response } from "express";
 import { ExternalUrls, PrefixedUrls, servicePathPrefix } from "../../constants";
 import errorManifest from "../../lib/utils/error-manifests/default";
 
@@ -50,7 +50,7 @@ export abstract class GenericHandler<T extends BaseViewData> {
         };
     }
 
-    populateViewData (req: Request) {
+    populateViewData (req: Request, res: Response) {
         const { signin_info: signInInfo } = req.session?.data ?? {};
         // eslint-disable-next-line camelcase
         const isSignedIn = signInInfo?.signed_in !== undefined;
@@ -67,10 +67,10 @@ export abstract class GenericHandler<T extends BaseViewData> {
         this.viewData.userEmail = userEmail;
     }
 
-    async getViewData (req: Request): Promise<T> {
+    async getViewData (req: Request, res: Response): Promise<T> {
         this.errorManifest = errorManifest;
         this.viewData = defaultBaseViewData as T;
-        this.populateViewData(req);
+        this.populateViewData(req, res);
         return this.viewData;
     }
 }

--- a/src/routers/handlers/individual-psc-list/individualPscListHandler.ts
+++ b/src/routers/handlers/individual-psc-list/individualPscListHandler.ts
@@ -6,8 +6,6 @@ import { getUrlWithTransactionIdAndSubmissionId } from "../../../utils/url";
 import { BaseViewData, GenericHandler, ViewModel } from "../generic";
 import { CompanyPersonWithSignificantControlResource } from "@companieshouse/api-sdk-node/dist/services/company-psc/types";
 import { getCompanyIndividualPscList } from "../../../services/companyPscService";
-import { CompanyProfile } from "@companieshouse/api-sdk-node/dist/services/company-profile/types";
-import { getCompanyProfile } from "../../../services/companyProfileService";
 
 interface IndividualPscData {
     pscId: string | any;
@@ -31,9 +29,7 @@ export class IndividualPscListHandler extends GenericHandler<IndividualPscListVi
         const locales = getLocalesService();
         const verification = res.locals.submission;
         const companyNumber = verification?.data?.company_number as string;
-        // req.query.companyNumber = companyNumber;
-        // TODO: fetch with middleware!
-        const companyProfile: CompanyProfile = await getCompanyProfile(req, companyNumber);
+        const companyProfile = res.locals.companyProfile;
 
         let companyName: string = "";
         if (companyProfile) {

--- a/src/routers/handlers/individual-psc-list/individualPscListHandler.ts
+++ b/src/routers/handlers/individual-psc-list/individualPscListHandler.ts
@@ -6,9 +6,6 @@ import { getUrlWithTransactionIdAndSubmissionId } from "../../../utils/url";
 import { BaseViewData, GenericHandler, ViewModel } from "../generic";
 import { CompanyPersonWithSignificantControlResource } from "@companieshouse/api-sdk-node/dist/services/company-psc/types";
 import { getCompanyIndividualPscList } from "../../../services/companyPscService";
-import { getPscVerification } from "../../../services/pscVerificationService";
-import { PscVerificationResource } from "@companieshouse/api-sdk-node/dist/services/psc-verification-link/types";
-import { Resource } from "@companieshouse/api-sdk-node";
 import { CompanyProfile } from "@companieshouse/api-sdk-node/dist/services/company-profile/types";
 import { getCompanyProfile } from "../../../services/companyProfileService";
 
@@ -27,16 +24,15 @@ export class IndividualPscListHandler extends GenericHandler<IndividualPscListVi
 
     private static templatePath = "router_views/individualPscList/individualPscList";
 
-    public async getViewData (req: Request): Promise<IndividualPscListViewData> {
+    public async getViewData (req: Request, res: Response): Promise<IndividualPscListViewData> {
 
-        const baseViewData = await super.getViewData(req);
+        const baseViewData = await super.getViewData(req, res);
         const lang = selectLang(req.query.lang);
-        const pscType: any = req.query.pscType;
         const locales = getLocalesService();
-        // Gets the JSON of the PSC
-        const getResponse: Resource<PscVerificationResource> = await getPscVerification(req, req.params.transactionId, req.params.submissionId);
-        const companyNumber = getResponse?.resource?.data?.company_number as string;
-        req.query.companyNumber = companyNumber;
+        const verification = res.locals.submission;
+        const companyNumber = verification?.data?.company_number as string;
+        // req.query.companyNumber = companyNumber;
+        // TODO: fetch with middleware!
         const companyProfile: CompanyProfile = await getCompanyProfile(req, companyNumber);
 
         let companyName: string = "";
@@ -64,9 +60,9 @@ export class IndividualPscListHandler extends GenericHandler<IndividualPscListVi
         };
     }
 
-    public async executeGet (req: Request, _response: Response): Promise<ViewModel<IndividualPscListViewData>> {
+    public async executeGet (req: Request, res: Response): Promise<ViewModel<IndividualPscListViewData>> {
         logger.info(`IndividualPscListHandler execute called`);
-        const viewData = await this.getViewData(req);
+        const viewData = await this.getViewData(req, res);
 
         return {
             templatePath: IndividualPscListHandler.templatePath,

--- a/src/routers/handlers/individual-statement/individualStatement.ts
+++ b/src/routers/handlers/individual-statement/individualStatement.ts
@@ -2,7 +2,6 @@ import { Request, Response } from "express";
 import { PrefixedUrls } from "../../../constants";
 import { logger } from "../../../lib/logger";
 import { getPscIndividual } from "../../../services/pscService";
-import { getPscVerification } from "../../../services/pscVerificationService";
 import { getLocaleInfo, getLocalesService, selectLang } from "../../../utils/localise";
 import { addSearchParams } from "../../../utils/queryParams";
 import { getUrlWithTransactionIdAndSubmissionId } from "../../../utils/url";
@@ -15,15 +14,15 @@ export class IndividualStatementHandler extends GenericHandler<IndividualStateme
 
     private static templatePath = "router_views/individual_statement/individual_statement";
 
-    public async getViewData (req: Request): Promise<IndividualStatementViewData> {
+    public async getViewData (req: Request, res: Response): Promise<IndividualStatementViewData> {
 
-        const baseViewData = await super.getViewData(req);
-        const verificationResponse = await getPscVerification(req, req.params.transactionId, req.params.submissionId);
-        const pscDetailsResponse = await getPscIndividual(req, verificationResponse.resource?.data.company_number as string,
-                                                verificationResponse.resource?.data.psc_appointment_id as string);
+        const baseViewData = await super.getViewData(req, res);
+        const verificationResource = res.locals.submission;
+        const pscDetailsResponse = await getPscIndividual(req, verificationResource?.data.company_number as string,
+                                                verificationResource?.data.psc_appointment_id as string);
         const lang = selectLang(req.query.lang);
         const locales = getLocalesService();
-        const selectedStatements = verificationResponse.resource?.data?.verification_details?.verification_statements || [];
+        const selectedStatements = verificationResource?.data?.verification_details?.verification_statements || [];
 
         return {
             ...baseViewData,
@@ -40,9 +39,9 @@ export class IndividualStatementHandler extends GenericHandler<IndividualStateme
         }
     }
 
-    public async executeGet (req: Request, _response: Response): Promise<ViewModel<IndividualStatementViewData>> {
+    public async executeGet (req: Request, res: Response): Promise<ViewModel<IndividualStatementViewData>> {
         logger.info(`IndividualStatementHandler execute called`);
-        const viewData = await this.getViewData(req);
+        const viewData = await this.getViewData(req, res);
 
         return {
             templatePath: IndividualStatementHandler.templatePath,
@@ -50,7 +49,7 @@ export class IndividualStatementHandler extends GenericHandler<IndividualStateme
         };
     }
 
-    public async executePost (req: Request, _response: Response) {
+    public async executePost (req: Request, res: Response) {
         const statement: string = req.body.psc_individual_statement; // a single string rather than string[] is returned (because there is only 1 checkbox in the group?)
         const selectedStatements = [statement];
         // TODO: here we would patch the Resource with the statements

--- a/src/routers/handlers/not-a-director/notADirector.ts
+++ b/src/routers/handlers/not-a-director/notADirector.ts
@@ -16,9 +16,9 @@ export class NotADirectorHandler extends GenericHandler<NotADirectorViewData> {
 
     private static templatePath = "router_views/not_a_director/not_a_director";
 
-    public async getViewData (req: Request): Promise<NotADirectorViewData> {
+    public async getViewData (req: Request, res: Response): Promise<NotADirectorViewData> {
 
-        const baseViewData = await super.getViewData(req);
+        const baseViewData = await super.getViewData(req, res);
 
         const lang = selectLang(req.query.lang);
         const locales = getLocalesService();
@@ -32,12 +32,9 @@ export class NotADirectorHandler extends GenericHandler<NotADirectorViewData> {
         };
     }
 
-    public async executeGet (
-        req: Request,
-        _response: Response
-    ): Promise<ViewModel<NotADirectorViewData>> {
+    public async executeGet (req: Request, res: Response): Promise<ViewModel<NotADirectorViewData>> {
         logger.info(`NotADirectorHandler execute called`);
-        const viewData = await this.getViewData(req);
+        const viewData = await this.getViewData(req, res);
 
         return {
             templatePath: NotADirectorHandler.templatePath,

--- a/src/routers/handlers/personal-code/personalCode.ts
+++ b/src/routers/handlers/personal-code/personalCode.ts
@@ -21,9 +21,9 @@ export class PersonalCodeHandler extends GenericHandler<PersonalCodeViewData> {
 
     private static templatePath = "router_views/personal_code/personal_code";
 
-    public async getViewData (req: Request): Promise<PersonalCodeViewData> {
+    public async getViewData (req: Request, res: Response): Promise<PersonalCodeViewData> {
 
-        const baseViewData = await super.getViewData(req);
+        const baseViewData = await super.getViewData(req, res);
         const pscIndividual = await getPscIndividualDetails(req, req.params.transactionId, req.params.submissionId);
         const lang = selectLang(req.query.lang);
         const locales = getLocalesService();
@@ -38,12 +38,9 @@ export class PersonalCodeHandler extends GenericHandler<PersonalCodeViewData> {
         };
     }
 
-    public async executeGet (
-        req: Request,
-        _response: Response
-    ): Promise<ViewModel<PersonalCodeViewData>> {
+    public async executeGet (req: Request, res: Response): Promise<ViewModel<PersonalCodeViewData>> {
         logger.info(`PersonalCodeHandler execute called`);
-        const viewData = await this.getViewData(req);
+        const viewData = await this.getViewData(req, res);
 
         return {
             templatePath: PersonalCodeHandler.templatePath,

--- a/src/routers/handlers/psc-type/pscType.ts
+++ b/src/routers/handlers/psc-type/pscType.ts
@@ -10,8 +10,8 @@ export class PscTypeHandler extends GenericHandler<PscTypeViewData> {
 
     private static templatePath = "router_views/psc_type/psc_type";
 
-    public async getViewData (req: Request): Promise<PscTypeViewData> {
-        const baseViewData = await super.getViewData(req);
+    public async getViewData (req: Request, res: Response): Promise<PscTypeViewData> {
+        const baseViewData = await super.getViewData(req, res);
         const lang = selectLang(req.query.lang);
         const locales = getLocalesService();
         const companyNumber = req.session?.getExtraData(SessionKeys.COMPANY_NUMBER) as string;
@@ -27,9 +27,9 @@ export class PscTypeHandler extends GenericHandler<PscTypeViewData> {
         };
     }
 
-    public async executeGet (req: Request, _response: Response): Promise<ViewModel<PscTypeViewData>> {
+    public async executeGet (req: Request, res: Response): Promise<ViewModel<PscTypeViewData>> {
         logger.info(`PscTypeHandler execute called`);
-        const viewData = await this.getViewData(req);
+        const viewData = await this.getViewData(req, res);
 
         viewData.pscType = req.query.pscType as string;
 

--- a/src/routers/handlers/psc-verified/pscVerifiedHandler.ts
+++ b/src/routers/handlers/psc-verified/pscVerifiedHandler.ts
@@ -23,9 +23,9 @@ export class PscVerifiedHandler extends GenericHandler<PscVerifiedViewData> {
 
     private static templatePath = "router_views/pscVerified/pscVerified";
 
-    public async getViewData (req: Request): Promise<PscVerifiedViewData> {
+    public async getViewData (req: Request, res: Response): Promise<PscVerifiedViewData> {
 
-        const baseViewData = await super.getViewData(req);
+        const baseViewData = await super.getViewData(req, res);
         const lang = selectLang(req.query.lang);
         const locales = getLocalesService();
         const transactionId = req.params.transactionId;
@@ -50,12 +50,9 @@ export class PscVerifiedHandler extends GenericHandler<PscVerifiedViewData> {
         };
     }
 
-    public async executeGet (
-        req: Request,
-        _response: Response
-    ): Promise<ViewModel<PscVerifiedViewData>> {
+    public async executeGet (req: Request, res: Response): Promise<ViewModel<PscVerifiedViewData>> {
         logger.info(`PscVerifiedHandler execute called`);
-        const viewData = await this.getViewData(req);
+        const viewData = await this.getViewData(req, res);
 
         const closure = await closeTransaction(req, req.params.transactionId, req.params.submissionId)
             .then((data) => {

--- a/src/routers/handlers/psc-verified/pscVerifiedHandler.ts
+++ b/src/routers/handlers/psc-verified/pscVerifiedHandler.ts
@@ -1,7 +1,5 @@
 import { Request, Response } from "express";
 import { getPscIndividual } from "../../../services/pscService";
-import { getPscVerification } from "../../../services/pscVerificationService";
-import { getCompanyProfile } from "../../../services/companyProfileService";
 import { closeTransaction } from "../../../services/transactionService";
 import { ExternalUrls, PrefixedUrls } from "../../../constants";
 import { logger } from "../../../lib/logger";
@@ -30,10 +28,11 @@ export class PscVerifiedHandler extends GenericHandler<PscVerifiedViewData> {
         const locales = getLocalesService();
         const transactionId = req.params.transactionId;
         const submissionId = req.params.submissionId;
-        const verificationResponse = await getPscVerification(req, transactionId, submissionId);
-        const companyNumber = verificationResponse.resource?.data.company_number as string;
-        const pscAppointmentId = verificationResponse.resource?.data.psc_appointment_id as string;
-        const [pscDetailsResponse, companyProfile] = await Promise.all([getPscIndividual(req, companyNumber, pscAppointmentId), getCompanyProfile(req, companyNumber)]);
+        const verification = res.locals.submission;
+        const companyNumber = verification?.data?.company_number as string;
+        const companyProfile = res.locals.companyProfile;
+        const pscAppointmentId = verification?.data.psc_appointment_id as string;
+        const pscDetailsResponse = await getPscIndividual(req, companyNumber, pscAppointmentId);
         const companyName = companyProfile.companyName as string;
         const forward = decodeURI(addSearchParams(ExternalUrls.COMPANY_LOOKUP_FORWARD, { companyNumber: "{companyNumber}", lang }));
 

--- a/src/routers/handlers/rle-details/rleDetails.ts
+++ b/src/routers/handlers/rle-details/rleDetails.ts
@@ -16,9 +16,9 @@ export class RleDetailsHandler extends GenericHandler<RleListViewData> {
 
     private static templatePath = "router_views/rleDetails/rleDetails";
 
-    public async getViewData (req: Request): Promise<RleListViewData> {
+    public async getViewData (req: Request, res: Response): Promise<RleListViewData> {
 
-        const baseViewData = await super.getViewData(req);
+        const baseViewData = await super.getViewData(req, res);
 
         const lang = selectLang(req.query.lang);
         const locales = getLocalesService();
@@ -32,12 +32,9 @@ export class RleDetailsHandler extends GenericHandler<RleListViewData> {
         };
     }
 
-    public async executeGet (
-        req: Request,
-        _response: Response
-    ): Promise<ViewModel<RleListViewData>> {
+    public async executeGet (req: Request, res: Response): Promise<ViewModel<RleListViewData>> {
         logger.info(`RleDetailsHandler execute called`);
-        const viewData = await this.getViewData(req);
+        const viewData = await this.getViewData(req, res);
 
         return {
             templatePath: RleDetailsHandler.templatePath,

--- a/src/routers/handlers/rle-director/rleDirector.ts
+++ b/src/routers/handlers/rle-director/rleDirector.ts
@@ -16,9 +16,9 @@ export class RleDirectorHandler extends GenericHandler<RleListViewData> {
 
     private static templatePath = "router_views/rle-director/rleDirector";
 
-    public async getViewData (req: Request): Promise<RleListViewData> {
+    public async getViewData (req: Request, res: Response): Promise<RleListViewData> {
 
-        const baseViewData = await super.getViewData(req);
+        const baseViewData = await super.getViewData(req, res);
 
         const lang = selectLang(req.query.lang);
         const locales = getLocalesService();
@@ -32,12 +32,9 @@ export class RleDirectorHandler extends GenericHandler<RleListViewData> {
         };
     }
 
-    public async executeGet (
-        req: Request,
-        _response: Response
-    ): Promise<ViewModel<RleListViewData>> {
+    public async executeGet (req: Request, res: Response): Promise<ViewModel<RleListViewData>> {
         logger.info(`RleDirectorHandler execute called`);
-        const viewData = await this.getViewData(req);
+        const viewData = await this.getViewData(req, res);
 
         return {
             templatePath: RleDirectorHandler.templatePath,

--- a/src/routers/handlers/rle-psc-list/rlePscList.ts
+++ b/src/routers/handlers/rle-psc-list/rlePscList.ts
@@ -17,9 +17,9 @@ export class RleListHandler extends GenericHandler<RleListViewData> {
 
     private static templatePath = "router_views/rlePscList/rlePscList";
 
-    public async getViewData (req: Request): Promise<RleListViewData> {
+    public async getViewData (req: Request, res: Response): Promise<RleListViewData> {
 
-        const baseViewData = await super.getViewData(req);
+        const baseViewData = await super.getViewData(req, res);
 
         const lang = selectLang(req.query.lang);
         const locales = getLocalesService();
@@ -34,12 +34,9 @@ export class RleListHandler extends GenericHandler<RleListViewData> {
         };
     }
 
-    public async executeGet (
-        req: Request,
-        _response: Response
-    ): Promise<ViewModel<RleListViewData>> {
+    public async executeGet (req: Request, res: Response): Promise<ViewModel<RleListViewData>> {
         logger.info(`RleListHandler execute called`);
-        const viewData = await this.getViewData(req);
+        const viewData = await this.getViewData(req, res);
 
         return {
             templatePath: RleListHandler.templatePath,

--- a/src/routers/handlers/rle-verified/rleVerified.ts
+++ b/src/routers/handlers/rle-verified/rleVerified.ts
@@ -16,9 +16,9 @@ export class RleVerifiedHandler extends GenericHandler<RleVerifiedViewData> {
 
     private static templatePath = "router_views/rle_verified/rleVerified";
 
-    public async getViewData (req: Request): Promise<RleVerifiedViewData> {
+    public async getViewData (req: Request, res: Response): Promise<RleVerifiedViewData> {
 
-        const baseViewData = await super.getViewData(req);
+        const baseViewData = await super.getViewData(req, res);
 
         const lang = selectLang(req.query.lang);
         const locales = getLocalesService();
@@ -32,12 +32,9 @@ export class RleVerifiedHandler extends GenericHandler<RleVerifiedViewData> {
         };
     }
 
-    public async executeGet (
-        req: Request,
-        _response: Response
-    ): Promise<ViewModel<RleVerifiedViewData>> {
+    public async executeGet (req: Request, res: Response): Promise<ViewModel<RleVerifiedViewData>> {
         logger.info(`RleVerifiedHandler execute called`);
-        const viewData = await this.getViewData(req);
+        const viewData = await this.getViewData(req, res);
 
         return {
             templatePath: RleVerifiedHandler.templatePath,

--- a/src/routers/handlers/start/start.ts
+++ b/src/routers/handlers/start/start.ts
@@ -9,8 +9,8 @@ export class StartHandler extends GenericHandler<BaseViewData> {
 
     public static templatePath = "router_views/start/start";
 
-    public async getViewData (req: Request): Promise<BaseViewData> {
-        const baseViewData = await super.getViewData(req);
+    public async getViewData (req: Request, res: Response): Promise<BaseViewData> {
+        const baseViewData = await super.getViewData(req, res);
         // adding language functionality
         const lang = selectLang(req.query.lang);
         const locales = getLocalesService();
@@ -26,13 +26,13 @@ export class StartHandler extends GenericHandler<BaseViewData> {
         };
     }
 
-    public async execute (req: Request, _response: Response): Promise<ViewModel<BaseViewData>> {
+    public async execute (req: Request, res: Response): Promise<ViewModel<BaseViewData>> {
         logger.info(`GET request to serve start page`);
         // ...process request here and return data for the view
 
         return {
             templatePath: StartHandler.templatePath,
-            viewData: await this.getViewData(req)
+            viewData: await this.getViewData(req, res)
         };
     }
 };

--- a/src/routers/individualPscListRouter.ts
+++ b/src/routers/individualPscListRouter.ts
@@ -1,20 +1,19 @@
 import { NextFunction, Request, Response, Router } from "express";
-import { PrefixedUrls, Urls } from "../constants";
-import { authenticate } from "../middleware/authentication";
+import { PrefixedUrls } from "../constants";
 import { handleExceptions } from "../utils/asyncHandler";
 import { selectLang } from "../utils/localise";
 import { getUrlWithTransactionIdAndSubmissionId } from "../utils/url";
 import { IndividualPscListHandler } from "./handlers/individual-psc-list/individualPscListHandler";
 
-const router: Router = Router();
+const router: Router = Router({ mergeParams: true });
 
-router.get(Urls.INDIVIDUAL_PSC_LIST, authenticate, handleExceptions(async (req: Request, res: Response, _next: NextFunction) => {
+router.get("/", handleExceptions(async (req: Request, res: Response, _next: NextFunction) => {
     const handler = new IndividualPscListHandler();
     const { templatePath, viewData } = await handler.executeGet(req, res);
     res.render(templatePath, viewData);
 }));
 
-router.post(Urls.INDIVIDUAL_PSC_LIST, authenticate, handleExceptions(async (req: Request, res: Response, _next: NextFunction) => {
+router.post("/", handleExceptions(async (req: Request, res: Response, _next: NextFunction) => {
     const handler = new IndividualPscListHandler();
     await handler.executePost(req, res);
 

--- a/src/routers/individualStatementRouter.ts
+++ b/src/routers/individualStatementRouter.ts
@@ -1,21 +1,20 @@
 import { NextFunction, Request, Response, Router } from "express";
-import { PrefixedUrls, Urls } from "../constants";
-import { authenticate } from "../middleware/authentication";
+import { PrefixedUrls } from "../constants";
 import { handleExceptions } from "../utils/asyncHandler";
 import { selectLang } from "../utils/localise";
 import { addSearchParams } from "../utils/queryParams";
 import { getUrlWithTransactionIdAndSubmissionId } from "../utils/url";
 import { IndividualStatementHandler } from "./handlers/individual-statement/individualStatement";
 
-const router: Router = Router();
+const router: Router = Router({ mergeParams: true });
 
-router.get(Urls.INDIVIDUAL_STATEMENT, authenticate, handleExceptions(async (req: Request, res: Response) => {
+router.get("/", handleExceptions(async (req: Request, res: Response) => {
     const handler = new IndividualStatementHandler();
     const { templatePath, viewData } = await handler.executeGet(req, res);
     res.render(templatePath, viewData);
 }));
 
-router.post(Urls.INDIVIDUAL_STATEMENT, authenticate, handleExceptions(async (req: Request, res: Response, _next: NextFunction) => {
+router.post("/", handleExceptions(async (req: Request, res: Response, _next: NextFunction) => {
     const handler = new IndividualStatementHandler();
     await handler.executePost(req, res);
 

--- a/src/routers/notADirectorRouter.ts
+++ b/src/routers/notADirectorRouter.ts
@@ -1,11 +1,10 @@
 import { Request, Response, Router } from "express";
-import { Urls } from "../constants";
-import { authenticate } from "../middleware/authentication";
 import { handleExceptions } from "../utils/asyncHandler";
 import { NotADirectorHandler } from "./handlers/not-a-director/notADirector";
-const router: Router = Router();
 
-router.get(Urls.NOT_A_DIRECTOR, authenticate, handleExceptions(async (req: Request, res: Response) => {
+const router: Router = Router({ mergeParams: true });
+
+router.get("/", handleExceptions(async (req: Request, res: Response) => {
     const handler = new NotADirectorHandler();
     const { templatePath, viewData } = await handler.executeGet(req, res);
     res.render(templatePath, viewData);

--- a/src/routers/personalCodeRouter.ts
+++ b/src/routers/personalCodeRouter.ts
@@ -1,21 +1,20 @@
 import { NextFunction, Request, Response, Router } from "express";
-import { PrefixedUrls, Urls } from "../constants";
-import { authenticate } from "../middleware/authentication";
+import { PrefixedUrls } from "../constants";
 import { handleExceptions } from "../utils/asyncHandler";
 import { PersonalCodeHandler } from "./handlers/personal-code/personalCode";
 import { selectLang } from "../utils/localise";
 import { getUrlWithTransactionIdAndSubmissionId } from "../utils/url";
 import { addSearchParams } from "../utils/queryParams";
 
-const router: Router = Router();
+const router: Router = Router({ mergeParams: true });
 
-router.get(Urls.PERSONAL_CODE, authenticate, handleExceptions(async (req: Request, res: Response) => {
+router.get("/", handleExceptions(async (req: Request, res: Response) => {
     const handler = new PersonalCodeHandler();
     const { templatePath, viewData } = await handler.executeGet(req, res);
     res.render(templatePath, viewData);
 }));
 
-router.post(Urls.PERSONAL_CODE, authenticate, handleExceptions(async (req: Request, res: Response, _next: NextFunction) => {
+router.post("/", handleExceptions(async (req: Request, res: Response, _next: NextFunction) => {
     const lang = selectLang(req.body.lang);
 
     const nextPageUrl = getUrlWithTransactionIdAndSubmissionId(PrefixedUrls.INDIVIDUAL_STATEMENT, req.params.transactionId, req.params.submissionId);

--- a/src/routers/pscTypeRouter.ts
+++ b/src/routers/pscTypeRouter.ts
@@ -1,28 +1,13 @@
 import { NextFunction, Request, Response, Router } from "express";
-import { PrefixedUrls, Urls } from "../constants";
-import { authenticate } from "../middleware/authentication";
+import { PrefixedUrls } from "../constants";
 import { handleExceptions } from "../utils/asyncHandler";
 import { selectLang } from "../utils/localise";
 import { getUrlWithTransactionIdAndSubmissionId } from "../utils/url";
 import { PscTypeHandler } from "./handlers/psc-type/pscType";
-import { logger } from "../lib/logger";
-import { getPscVerification } from "../services/pscVerificationService";
 
-const router: Router = Router();
+const router: Router = Router({ mergeParams: true });
 
-router.param("submissionId", async (req, res, next, submissionId) => {
-    // TODO: no need to retrieve the submission data for this screen:
-    // 1) the PSC Type is not stored in the database explicitly
-    // 2) selection of PSC type on this screen is captured by request query param 'pscType'
-    // 3) this code is left here for now, should be moved to routers for screens that require the submission data
-    logger.debug(`Resolved :submissionId=${req.params.submissionId}, retrieving submission resource...`);
-    const response = await getPscVerification(req, req.params.transactionId, req.params.submissionId);
-    // store the submission in the request.locals (per express SOP)
-    res.locals.submission = response.resource;
-    next();
-});
-
-router.get(Urls.PSC_TYPE, authenticate, handleExceptions(async (req: Request, res: Response, _next: NextFunction) => {
+router.get("/", handleExceptions(async (req: Request, res: Response, _next: NextFunction) => {
     const handler = new PscTypeHandler();
     const params = await handler.executeGet(req, res);
 
@@ -31,7 +16,7 @@ router.get(Urls.PSC_TYPE, authenticate, handleExceptions(async (req: Request, re
     }
 }));
 
-router.post(Urls.PSC_TYPE, authenticate, handleExceptions(async (req: Request, res: Response, _next: NextFunction) => {
+router.post("/", handleExceptions(async (req: Request, res: Response, _next: NextFunction) => {
     const lang = selectLang(req.body.lang);
     const selectedType = req.body.pscType;
     const queryParams = new URLSearchParams(req.url.split("?")[1]);

--- a/src/routers/pscVerifiedRouter.ts
+++ b/src/routers/pscVerifiedRouter.ts
@@ -1,11 +1,9 @@
 import { Request, Response, Router } from "express";
-import { Urls } from "../constants";
-import { authenticate } from "../middleware/authentication";
 import { handleExceptions } from "../utils/asyncHandler";
 import { PscVerifiedHandler } from "./handlers/psc-verified/pscVerifiedHandler";
-const router: Router = Router();
+const router: Router = Router({ mergeParams: true });
 
-router.get(Urls.PSC_VERIFIED, authenticate, handleExceptions(async (req: Request, res: Response) => {
+router.get("/", handleExceptions(async (req: Request, res: Response) => {
     const handler = new PscVerifiedHandler();
     const { templatePath, viewData } = await handler.executeGet(req, res);
     res.render(templatePath, viewData);

--- a/src/routers/rleDetailsRouter.ts
+++ b/src/routers/rleDetailsRouter.ts
@@ -1,11 +1,10 @@
 import { Request, Response, Router } from "express";
-import { Urls } from "../constants";
-import { authenticate } from "../middleware/authentication";
 import { handleExceptions } from "../utils/asyncHandler";
 import { RleDetailsHandler } from "./handlers/rle-details/rleDetails";
-const router: Router = Router();
 
-router.get(Urls.RLE_DETAILS, authenticate, handleExceptions(async (req: Request, res: Response) => {
+const router: Router = Router({ mergeParams: true });
+
+router.get("/", handleExceptions(async (req: Request, res: Response) => {
     const handler = new RleDetailsHandler();
     const { templatePath, viewData } = await handler.executeGet(req, res);
     res.render(templatePath, viewData);

--- a/src/routers/rleDirectorRouter.ts
+++ b/src/routers/rleDirectorRouter.ts
@@ -1,11 +1,10 @@
 import { Request, Response, Router } from "express";
-import { Urls } from "../constants";
-import { authenticate } from "../middleware/authentication";
 import { handleExceptions } from "../utils/asyncHandler";
 import { RleDirectorHandler } from "./handlers/rle-director/rleDirector";
-const router: Router = Router();
 
-router.get(Urls.RLE_DIRECTOR, authenticate, handleExceptions(async (req: Request, res: Response) => {
+const router: Router = Router({ mergeParams: true });
+
+router.get("/", handleExceptions(async (req: Request, res: Response) => {
     const handler = new RleDirectorHandler();
     const { templatePath, viewData } = await handler.executeGet(req, res);
     res.render(templatePath, viewData);

--- a/src/routers/rlePscListRouter.ts
+++ b/src/routers/rlePscListRouter.ts
@@ -1,11 +1,10 @@
 import { Request, Response, Router } from "express";
-import { Urls } from "../constants";
-import { authenticate } from "../middleware/authentication";
 import { handleExceptions } from "../utils/asyncHandler";
 import { RleListHandler } from "./handlers/rle-psc-list/rlePscList";
-const router: Router = Router();
 
-router.get(Urls.RLE_LIST, authenticate, handleExceptions(async (req: Request, res: Response) => {
+const router: Router = Router({ mergeParams: true });
+
+router.get("/", handleExceptions(async (req: Request, res: Response) => {
     const handler = new RleListHandler();
     const { templatePath, viewData } = await handler.executeGet(req, res);
     res.render(templatePath, viewData);

--- a/src/routers/rleVerifiedRouter.ts
+++ b/src/routers/rleVerifiedRouter.ts
@@ -1,11 +1,10 @@
 import { Request, Response, Router } from "express";
-import { Urls } from "../constants";
-import { authenticate } from "../middleware/authentication";
 import { handleExceptions } from "../utils/asyncHandler";
 import { RleVerifiedHandler } from "./handlers/rle-verified/rleVerified";
-const router: Router = Router();
 
-router.get(Urls.RLE_VERIFIED, authenticate, handleExceptions(async (req: Request, res: Response) => {
+const router: Router = Router({ mergeParams: true });
+
+router.get("/", handleExceptions(async (req: Request, res: Response) => {
     const handler = new RleVerifiedHandler();
     const { templatePath, viewData } = await handler.executeGet(req, res);
     res.render(templatePath, viewData);

--- a/test/middleware/fetchCompany.unit.ts
+++ b/test/middleware/fetchCompany.unit.ts
@@ -1,0 +1,82 @@
+import { INDIVIDUAL_DATA, PSC_VERIFICATION_ID, TRANSACTION_ID } from "../mocks/pscVerification.mock";
+import * as httpMocks from "node-mocks-http";
+import { PrefixedUrls } from "../../src/constants";
+import { getCompanyProfile } from "../../src/services/companyProfileService";
+import { validCompanyProfile } from "../mocks/companyProfile.mock";
+import { fetchCompany } from "../../src/middleware/fetchCompany";
+
+jest.mock("../../src/services/companyProfileService");
+const mockGetCompanyProfile = getCompanyProfile as jest.Mock;
+mockGetCompanyProfile.mockResolvedValueOnce(validCompanyProfile);
+
+const mockNext = jest.fn();
+
+describe("fetchCompany", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    const VALID_REQ: httpMocks.RequestOptions = {
+        method: "GET",
+        url: PrefixedUrls.PERSONAL_CODE,
+        params: {
+            transactionId: TRANSACTION_ID,
+            submissionId: PSC_VERIFICATION_ID
+        },
+        query: {
+            pscType: "individual"
+        }
+    };
+
+    it("should retrieve a company profile resource", async () => {
+        const req = httpMocks.createRequest(VALID_REQ);
+        const res = httpMocks.createResponse({ locals: { submission: { data: INDIVIDUAL_DATA } } });
+
+        await fetchCompany(req, res, mockNext);
+
+        expect(res.locals?.companyProfile).toBe(validCompanyProfile);
+        expect(mockNext).toHaveBeenCalled();
+        expect(mockGetCompanyProfile).toHaveBeenCalled();
+
+    });
+
+    it("should skip retrieval if companyNumber is missing", async () => {
+        const req = httpMocks.createRequest(VALID_REQ);
+        const res = httpMocks.createResponse({ locals: { submission: { data: { ...INDIVIDUAL_DATA, company_number: undefined } } } });
+
+        await fetchCompany(req, res, mockNext);
+
+        expect(res.locals?.companyProfile).toBeUndefined();
+        expect(mockNext).toHaveBeenCalled();
+        expect(mockGetCompanyProfile).not.toHaveBeenCalled();
+
+    });
+
+    it("should skip retrieval if submission is undefined", async () => {
+        const req = httpMocks.createRequest(VALID_REQ);
+        const res = httpMocks.createResponse({ locals: { submission: undefined } });
+
+        await fetchCompany(req, res, mockNext);
+
+        await fetchCompany(req, res, mockNext);
+
+        expect(res.locals?.companyProfile).toBeUndefined();
+        expect(mockNext).toHaveBeenCalled();
+        expect(mockGetCompanyProfile).not.toHaveBeenCalled();
+
+    });
+
+    it("should skip retrieval if submission is missing", async () => {
+        const req = httpMocks.createRequest(VALID_REQ);
+        const res = httpMocks.createResponse();
+
+        await fetchCompany(req, res, mockNext);
+
+        await fetchCompany(req, res, mockNext);
+
+        expect(res.locals?.companyProfile).toBeUndefined();
+        expect(mockNext).toHaveBeenCalled();
+        expect(mockGetCompanyProfile).not.toHaveBeenCalled();
+
+    });
+});

--- a/test/middleware/fetchVerification.unit.ts
+++ b/test/middleware/fetchVerification.unit.ts
@@ -1,0 +1,69 @@
+import { HttpStatusCode } from "axios";
+import { INDIVIDUAL_RESOURCE, PSC_VERIFICATION_ID, TRANSACTION_ID } from "../mocks/pscVerification.mock";
+import * as httpMocks from "node-mocks-http";
+import { PrefixedUrls } from "../../src/constants";
+import { fetchVerification } from "../../src/middleware/fetchVerification";
+import { getPscVerification } from "../../src/services/pscVerificationService";
+
+jest.mock("../../src/services/pscVerificationService");
+const mockGetPscVerification = getPscVerification as jest.Mock;
+mockGetPscVerification.mockResolvedValueOnce({
+    httpStatusCode: HttpStatusCode.Ok,
+    resource: INDIVIDUAL_RESOURCE
+});
+
+const mockNext = jest.fn();
+
+describe("fetchVerification", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    const VALID_REQ: httpMocks.RequestOptions = {
+        method: "GET",
+        url: PrefixedUrls.PERSONAL_CODE,
+        params: {
+            transactionId: TRANSACTION_ID,
+            submissionId: PSC_VERIFICATION_ID
+        },
+        query: {
+            pscType: "individual"
+        }
+    };
+
+    it("should retrieve a verification resource", async () => {
+        const req = httpMocks.createRequest(VALID_REQ);
+        const res = httpMocks.createResponse();
+
+        await fetchVerification(req, res, mockNext);
+
+        expect(res.locals?.submission).toBe(INDIVIDUAL_RESOURCE);
+        expect(mockNext).toHaveBeenCalled();
+        expect(mockGetPscVerification).toHaveBeenCalled();
+
+    });
+
+    it("should skip retrieval if transactionId is missing", async () => {
+        const req = httpMocks.createRequest({ ...VALID_REQ, params: { submissionId: PSC_VERIFICATION_ID } });
+        const res = httpMocks.createResponse();
+
+        await fetchVerification(req, res, mockNext);
+
+        expect(res.locals?.submission).toBeUndefined();
+        expect(mockNext).toHaveBeenCalled();
+        expect(mockGetPscVerification).not.toHaveBeenCalled();
+
+    });
+
+    it("should skip retrieval if submissionId is missing", async () => {
+        const req = httpMocks.createRequest({ ...VALID_REQ, params: { transactionId: TRANSACTION_ID } });
+        const res = httpMocks.createResponse();
+
+        await fetchVerification(req, res, mockNext);
+
+        expect(res.locals?.submission).toBeUndefined();
+        expect(mockNext).toHaveBeenCalled();
+        expect(mockGetPscVerification).not.toHaveBeenCalled();
+
+    });
+});

--- a/test/mocks/allMiddleware.mock.ts
+++ b/test/mocks/allMiddleware.mock.ts
@@ -1,7 +1,9 @@
 import mockAuthenticationMiddleware from "./authenticationMiddleware.mock";
+import mockFetchVerificationMiddleware from "./fetchVerification.mock";
 import mockSessionMiddleware from "./sessionMiddleware.mock";
 
 export default {
     mockSessionMiddleware,
-    mockAuthenticationMiddleware
+    mockAuthenticationMiddleware,
+    mockFetchVerificationMiddleware
 };

--- a/test/mocks/allMiddleware.mock.ts
+++ b/test/mocks/allMiddleware.mock.ts
@@ -1,9 +1,11 @@
 import mockAuthenticationMiddleware from "./authenticationMiddleware.mock";
+import mockFetchCompanyMiddleware from "./fetchCompany.mock";
 import mockFetchVerificationMiddleware from "./fetchVerification.mock";
 import mockSessionMiddleware from "./sessionMiddleware.mock";
 
 export default {
     mockSessionMiddleware,
     mockAuthenticationMiddleware,
-    mockFetchVerificationMiddleware
+    mockFetchVerificationMiddleware,
+    mockFetchCompanyMiddleware
 };

--- a/test/mocks/fetchCompany.mock.ts
+++ b/test/mocks/fetchCompany.mock.ts
@@ -1,0 +1,12 @@
+import { NextFunction, Request, Response } from "express";
+import { fetchCompany } from "../../src/middleware/fetchCompany";
+
+jest.mock("../../src/middleware/fetchCompany");
+
+// get handle on mocked function
+const mockFetchCompanyMiddleware = fetchCompany as jest.Mock;
+
+// tell the mock what to return
+mockFetchCompanyMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next());
+
+export default mockFetchCompanyMiddleware;

--- a/test/mocks/fetchVerification.mock.ts
+++ b/test/mocks/fetchVerification.mock.ts
@@ -1,0 +1,12 @@
+import { NextFunction, Request, Response } from "express";
+import { fetchVerification } from "../../src/middleware/fetchVerification";
+
+jest.mock("../../src/middleware/fetchVerification");
+
+// get handle on mocked function
+const mockFetchVerificationMiddleware = fetchVerification as jest.Mock;
+
+// tell the mock what to return
+mockFetchVerificationMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next());
+
+export default mockFetchVerificationMiddleware;

--- a/test/routers/handlers/individual-psc-list/individualPscListHandler.int.ts
+++ b/test/routers/handlers/individual-psc-list/individualPscListHandler.int.ts
@@ -2,51 +2,56 @@ import { HttpStatusCode } from "axios";
 import * as cheerio from "cheerio";
 import request from "supertest";
 import { URLSearchParams } from "url";
-import middlewareMocks from "../../../mocks/allMiddleware.mock";
+import mockSessionMiddleware from "../../../mocks/sessionMiddleware.mock";
+import mockAuthenticationMiddleware from "../../../mocks/authenticationMiddleware.mock";
 import app from "../../../../src/app";
 import { PrefixedUrls } from "../../../../src/constants";
 import { getUrlWithTransactionIdAndSubmissionId } from "../../../../src/utils/url";
-import { CREATED_RESOURCE, PSC_VERIFICATION_ID, TRANSACTION_ID } from "../../../mocks/pscVerification.mock";
+import { COMPANY_NUMBER, CREATED_RESOURCE, PSC_VERIFICATION_ID, TRANSACTION_ID } from "../../../mocks/pscVerification.mock";
 import { VALID_COMPANY_PSC_LIST } from "../../../mocks/companyPsc.mock";
 import { getCompanyProfile } from "../../../../src/services/companyProfileService";
 import { getPscVerification } from "../../../../src/services/pscVerificationService";
 import { validCompanyProfile } from "../../../mocks/companyProfile.mock";
+import { getCompanyIndividualPscList } from "../../../../src/services/companyPscService";
+import { IncomingMessage } from "http";
 
-jest.mock("../../../../src/services/pscVerificationService", () => ({
-    getPscVerification: () => ({
-        httpStatusCode: HttpStatusCode.Ok,
-        resource: CREATED_RESOURCE
-    })
-}));
+jest.mock("../../../../src/services/pscVerificationService");
+const mockGetPscVerification = getPscVerification as jest.Mock;
 
-jest.mock("../../../../src/services/companyPscService", () => ({
-    getCompanyIndividualPscList: () => ({
-        httpStatusCode: HttpStatusCode.Ok,
-        resource: VALID_COMPANY_PSC_LIST
-    })
-}));
+mockGetPscVerification.mockResolvedValueOnce({
+    httpStatusCode: HttpStatusCode.Ok,
+    resource: CREATED_RESOURCE
+});
 
 jest.mock("../../../../src/services/companyProfileService");
 const mockGetCompanyProfile = getCompanyProfile as jest.Mock;
-mockGetCompanyProfile.mockResolvedValue(validCompanyProfile);
+mockGetCompanyProfile.mockResolvedValueOnce(validCompanyProfile);
 
-const mockGetPscVerification = getPscVerification as jest.Mock;
+jest.mock("../../../../src/services/companyPscService");
+const mockGetCompanyIndividualPscList = getCompanyIndividualPscList as jest.Mock;
+
+mockGetCompanyIndividualPscList.mockResolvedValueOnce({
+    // FIXME: should be CompanyPersonWithSignificantControlResource[] with correct property names!
+    httpStatusCode: HttpStatusCode.Ok,
+    resource: VALID_COMPANY_PSC_LIST
+});
 
 describe("individual PSC list view", () => {
 
     beforeEach(() => {
-        middlewareMocks.mockSessionMiddleware.mockClear();
+        jest.clearAllMocks();
     });
 
     afterEach(() => {
-        expect(middlewareMocks.mockSessionMiddleware).toHaveBeenCalledTimes(1);
-        jest.clearAllMocks();
+        expect(mockSessionMiddleware).toHaveBeenCalledTimes(1);
+        expect(mockAuthenticationMiddleware).toHaveBeenCalledTimes(1);
     });
 
     it("Should render the Individual PSC List page with a success status code and correct links", async () => {
         const queryParams = new URLSearchParams("lang=en&pscType=individual");
         const uriWithQuery = `${PrefixedUrls.INDIVIDUAL_PSC_LIST}?${queryParams}`;
         const uri = getUrlWithTransactionIdAndSubmissionId(uriWithQuery, TRANSACTION_ID, PSC_VERIFICATION_ID);
+        mockGetPscVerification.mockResolvedValue(CREATED_RESOURCE);
 
         const resp = await request(app).get(uri);
 
@@ -54,6 +59,14 @@ describe("individual PSC list view", () => {
 
         expect(resp.status).toBe(HttpStatusCode.Ok);
         expect($("a.govuk-back-link").attr("href")).toBe("/persons-with-significant-control-verification/transaction/11111-22222-33333/submission/662a0de6a2c6f9aead0f32ab/psc-type?lang=en&pscType=individual");
+        // TODO: replace expectations below with checks on page HTML contents
+        expect(mockGetPscVerification).toHaveBeenCalledTimes(1);
+        expect(mockGetPscVerification).toHaveBeenCalledWith(expect.any(IncomingMessage), TRANSACTION_ID, PSC_VERIFICATION_ID);
+        expect(mockGetCompanyProfile).toHaveBeenCalledTimes(1);
+        expect(mockGetCompanyProfile).toHaveBeenCalledWith(expect.any(IncomingMessage), COMPANY_NUMBER);
+        expect(mockGetCompanyIndividualPscList).toHaveBeenCalledTimes(1);
+        expect(mockGetCompanyIndividualPscList).toHaveBeenCalledWith(expect.any(IncomingMessage), COMPANY_NUMBER);
+
     });
 
 });

--- a/test/routers/handlers/individual-statement/individualStatement.int.ts
+++ b/test/routers/handlers/individual-statement/individualStatement.int.ts
@@ -2,12 +2,15 @@ import { HttpStatusCode } from "axios";
 import * as cheerio from "cheerio";
 import request from "supertest";
 import { URLSearchParams } from "url";
-import middlewareMocks from "../../../mocks/allMiddleware.mock";
-import app from "../../../../src/app";
+import mockSessionMiddleware from "../../../mocks/sessionMiddleware.mock";
+import mockAuthenticationMiddleware from "../../../mocks/authenticationMiddleware.mock";
 import { PrefixedUrls } from "../../../../src/constants";
 import { getUrlWithTransactionIdAndSubmissionId } from "../../../../src/utils/url";
 import { PSC_INDIVIDUAL } from "../../../mocks/psc.mock";
 import { INDIVIDUAL_RESOURCE, PSC_VERIFICATION_ID, TRANSACTION_ID } from "../../../mocks/pscVerification.mock";
+import { getPscVerification } from "../../../../src/services/pscVerificationService";
+import app from "../../../../src/app";
+// import mockFetchVerificationMiddleware from "../../../mocks/fetchVerification.mock";
 
 jest.mock("../../../../src/services/pscVerificationService", () => ({
     getPscVerification: () => ({
@@ -22,14 +25,18 @@ jest.mock("../../../../src/services/pscService", () => ({
     })
 }));
 
+const mockGetPscVerification = getPscVerification as jest.Mock;
+
 describe("individual statement view", () => {
 
     beforeEach(() => {
-        middlewareMocks.mockSessionMiddleware.mockClear();
+        mockSessionMiddleware.mockClear();
+        mockAuthenticationMiddleware.mockClear();
     });
 
     afterEach(() => {
-        expect(middlewareMocks.mockSessionMiddleware).toHaveBeenCalledTimes(1);
+        expect(mockSessionMiddleware).toHaveBeenCalledTimes(1);
+        expect(mockAuthenticationMiddleware).toHaveBeenCalledTimes(1);
         jest.clearAllMocks();
     });
 

--- a/test/routers/handlers/individual-statement/individualStatement.unit.ts
+++ b/test/routers/handlers/individual-statement/individualStatement.unit.ts
@@ -6,19 +6,13 @@ import middlewareMocks from "../../../mocks/allMiddleware.mock";
 import { PSC_INDIVIDUAL } from "../../../mocks/psc.mock";
 import { INDIVIDUAL_RESOURCE, PSC_VERIFICATION_ID, TRANSACTION_ID } from "../../../mocks/pscVerification.mock";
 import { VerificationStatement } from "@companieshouse/api-sdk-node/dist/services/psc-verification-link/types";
-import { getPscVerification } from "../../../../src/services/pscVerificationService";
 
-jest.mock("../../../../src/services/pscVerificationService", () => ({
-    getPscVerification: jest.fn()
-}));
 jest.mock("../../../../src/services/pscService", () => ({
     getPscIndividual: () => ({
         httpStatusCode: HttpStatusCode.Ok,
         resource: PSC_INDIVIDUAL
     })
 }));
-
-const mockGetPscVerification = getPscVerification as jest.Mock;
 
 describe("Individual statement handler", () => {
     beforeEach(() => {
@@ -32,10 +26,6 @@ describe("Individual statement handler", () => {
     describe("executeGet", () => {
 
         it("should resolve correct view data", async () => {
-            mockGetPscVerification.mockResolvedValueOnce({
-                httpStatusCode: HttpStatusCode.Ok,
-                resource: INDIVIDUAL_RESOURCE
-            });
             const req = httpMocks.createRequest({
                 method: "GET",
                 url: Urls.PSC_VERIFIED,
@@ -47,7 +37,7 @@ describe("Individual statement handler", () => {
                     pscType: "individual"
                 }
             });
-            const res = httpMocks.createResponse();
+            const res = httpMocks.createResponse({ locals: { submission: INDIVIDUAL_RESOURCE } });
             const handler = new IndividualStatementHandler();
             const expectedPrefix = `/persons-with-significant-control-verification/transaction/${TRANSACTION_ID}/submission/${PSC_VERIFICATION_ID}`;
 
@@ -61,9 +51,6 @@ describe("Individual statement handler", () => {
                 dateOfBirth: "April 2000",
                 errors: {}
             });
-            expect(getPscVerification).toHaveBeenCalledTimes(1);
-            expect(getPscVerification).toHaveBeenCalledWith(req, TRANSACTION_ID, PSC_VERIFICATION_ID);
-
         });
     });
 

--- a/test/routers/handlers/psc-verified/pscVerified.int.ts
+++ b/test/routers/handlers/psc-verified/pscVerified.int.ts
@@ -1,28 +1,32 @@
 import { HttpStatusCode } from "axios";
 import request from "supertest";
-import middlewareMocks from "../../../mocks/allMiddleware.mock";
+import mockSessionMiddleware from "../../../mocks/sessionMiddleware.mock";
+import mockAuthenticationMiddleware from "../../../mocks/authenticationMiddleware.mock";
 import app from "../../../../src/app";
 import { PrefixedUrls } from "../../../../src/constants";
 import { getCompanyProfile } from "../../../../src/services/companyProfileService";
 import { closeTransaction } from "../../../../src/services/transactionService";
 import { PSC_INDIVIDUAL } from "../../../mocks/psc.mock";
-import { INDIVIDUAL_RESOURCE, PSC_VERIFICATION_ID, TRANSACTION_ID } from "../../../mocks/pscVerification.mock";
+import { COMPANY_NUMBER, INDIVIDUAL_RESOURCE, PSC_VERIFICATION_ID, TRANSACTION_ID } from "../../../mocks/pscVerification.mock";
 import { validCompanyProfile } from "../../../mocks/companyProfile.mock";
 import { getUrlWithTransactionIdAndSubmissionId } from "../../../../src/utils/url";
+import { getPscVerification } from "../../../../src/services/pscVerificationService";
+import { getPscIndividual } from "../../../../src/services/pscService";
+import { IncomingMessage } from "http";
 
-jest.mock("../../../../src/services/pscVerificationService", () => ({
-    getPscVerification: () => ({
-        httpStatusCode: HttpStatusCode.Ok,
-        resource: INDIVIDUAL_RESOURCE
-    })
-}));
+jest.mock("../../../../src/services/pscVerificationService");
+const mockGetPscVerification = getPscVerification as jest.Mock;
+mockGetPscVerification.mockResolvedValueOnce({
+    httpStatusCode: HttpStatusCode.Ok,
+    resource: INDIVIDUAL_RESOURCE
+});
 
-jest.mock("../../../../src/services/pscService", () => ({
-    getPscIndividual: () => ({
-        httpStatusCode: HttpStatusCode.Ok,
-        resource: PSC_INDIVIDUAL
-    })
-}));
+jest.mock("../../../../src/services/pscService");
+const mockGetPscIndividual = getPscIndividual as jest.Mock;
+mockGetPscIndividual.mockResolvedValueOnce({
+    httpStatusCode: HttpStatusCode.Ok,
+    resource: PSC_INDIVIDUAL
+});
 
 jest.mock("../../../../src/services/companyProfileService");
 const mockGetCompanyProfile = getCompanyProfile as jest.Mock;
@@ -37,18 +41,32 @@ mockCloseTransaction.mockResolvedValue({});
 describe("psc verified view tests", () => {
 
     beforeEach(() => {
-        middlewareMocks.mockSessionMiddleware.mockClear();
+        jest.clearAllMocks();
     });
 
     afterEach(() => {
-        expect(middlewareMocks.mockSessionMiddleware).toHaveBeenCalledTimes(1);
+        expect(mockSessionMiddleware).toHaveBeenCalledTimes(1);
+        expect(mockAuthenticationMiddleware).toHaveBeenCalledTimes(1);
     });
 
     it("Should render the PSC Verified Confirmation page with a success status code", async () => {
         const queryParams = new URLSearchParams("lang=en");
         const uriWithQuery = `${PrefixedUrls.PSC_VERIFIED}?${queryParams}`;
         const uri = getUrlWithTransactionIdAndSubmissionId(uriWithQuery, TRANSACTION_ID, PSC_VERIFICATION_ID);
+
         const response = await request(app).get(uri);
+
         expect(response.status).toBe(200);
+        expect(mockCloseTransaction).toHaveBeenCalledTimes(1);
+        expect(mockCloseTransaction).toHaveBeenCalledWith(expect.any(IncomingMessage), TRANSACTION_ID, PSC_VERIFICATION_ID);
+
+        // TODO: replace expectations below with checks on page HTML contents
+        expect(mockGetPscVerification).toHaveBeenCalledTimes(1);
+        expect(mockGetPscVerification).toHaveBeenCalledWith(expect.any(IncomingMessage), TRANSACTION_ID, PSC_VERIFICATION_ID);
+        expect(mockGetCompanyProfile).toHaveBeenCalledTimes(1);
+        expect(mockGetCompanyProfile).toHaveBeenCalledWith(expect.any(IncomingMessage), COMPANY_NUMBER);
+        expect(mockGetPscIndividual).toHaveBeenCalledTimes(1);
+        expect(mockGetPscIndividual).toHaveBeenCalledWith(expect.any(IncomingMessage), COMPANY_NUMBER, PSC_VERIFICATION_ID);
+
     });
 });

--- a/test/routers/individualPscListRouter.int.ts
+++ b/test/routers/individualPscListRouter.int.ts
@@ -59,6 +59,7 @@ describe("psc individual list tests", () => {
             .query({ lang: "en", pscType: "individual" })
             .expect(HttpStatusCode.Found)
             .expect("Location", expectedRedirectUrl);
+
     });
 
 });

--- a/test/routers/personalCodeRouter.int.ts
+++ b/test/routers/personalCodeRouter.int.ts
@@ -5,7 +5,6 @@ import request from "supertest";
 import app from "../../src/app";
 import { PrefixedUrls } from "../../src/constants";
 import { COMPANY_NUMBER, CREATED_RESOURCE, PSC_VERIFICATION_ID, TRANSACTION_ID } from "../mocks/pscVerification.mock";
-import { getPscVerification } from "../../src/services/pscVerificationService";
 import { getUrlWithTransactionIdAndSubmissionId } from "../../src/utils/url";
 import { PSC_INDIVIDUAL } from "../mocks/psc.mock";
 
@@ -22,7 +21,6 @@ jest.mock("../../src/services/pscService", () => ({
         resource: PSC_INDIVIDUAL
     })
 }));
-const mockGetPscVerification = getPscVerification as jest.Mock;
 
 beforeEach(() => {
     jest.clearAllMocks();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2017",
     "module": "commonjs",
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "Node",
     "pretty": true,
     "sourceMap": true,
     "outDir": "./dist",


### PR DESCRIPTION
Retrieve and store relevant data in `response.locals` for routes requiring the data:
- get PSC verification data through `fetchVerification` middleware
- get company profile data through `fetchCompany` middleware

