### PR TITLE
Defect fix - Transaction ID and Submission ID lost from path

### DIFF
--- a/src/routers/handlers/new-submission/newSubmissionHandler.ts
+++ b/src/routers/handlers/new-submission/newSubmissionHandler.ts
@@ -24,7 +24,7 @@ export class NewSubmissionHandler extends GenericHandler<BaseViewData> {
         logger.info(`CREATED New Resource ${resource?.resource?.links.self} `);
 
         // set up redirect to psc_type screen
-        const lang = selectLang(req.body.lang);
+        const lang = selectLang(req.query.lang);
         const regex = "significant-control-verification/(.*)$";
         const resourceId = resource.resource?.links.self.match(regex);
         const nextPageUrl = getUrlWithTransactionIdAndSubmissionId(PrefixedUrls.PSC_TYPE, transaction.id!, resourceId![1]);

--- a/src/routers/handlers/personal-code/personalCode.ts
+++ b/src/routers/handlers/personal-code/personalCode.ts
@@ -35,15 +35,15 @@ export class PersonalCodeHandler extends GenericHandler<PersonalCodeViewData> {
             ...getLocaleInfo(locales, lang),
             pscName: pscIndividual.resource?.name!,
             monthBorn: formatDateBorn(pscIndividual.resource?.dateOfBirth, selectLang(req.query.lang)),
-            currentUrl: addSearchParams(
-                getUrlWithTransactionIdAndSubmissionId(PrefixedUrls.PERSONAL_CODE, req.params.transactionId, req.params.submissionId),
-                { lang }),
-            backURL: addSearchParams(
-                getUrlWithTransactionIdAndSubmissionId(PrefixedUrls.INDIVIDUAL_PSC_LIST, req.params.transactionId, req.params.submissionId),
-                { lang }),
+            currentUrl: resolveUrlTemplate(PrefixedUrls.PERSONAL_CODE),
+            backURL: resolveUrlTemplate(PrefixedUrls.INDIVIDUAL_PSC_LIST),
             templateName: Urls.PERSONAL_CODE,
             backLinkDataEvent: "personal-code-back-link"
         };
+
+        function resolveUrlTemplate (prefixedUrl: string): string | null {
+            return addSearchParams(getUrlWithTransactionIdAndSubmissionId(prefixedUrl, req.params.transactionId, req.params.submissionId), { lang });
+        }
     }
 
     public async executeGet (req: Request, res: Response): Promise<ViewModel<PersonalCodeViewData>> {

--- a/src/routers/handlers/personal-code/personalCode.ts
+++ b/src/routers/handlers/personal-code/personalCode.ts
@@ -35,8 +35,12 @@ export class PersonalCodeHandler extends GenericHandler<PersonalCodeViewData> {
             ...getLocaleInfo(locales, lang),
             pscName: pscIndividual.resource?.name!,
             monthBorn: formatDateBorn(pscIndividual.resource?.dateOfBirth, selectLang(req.query.lang)),
-            currentUrl: addSearchParams(PrefixedUrls.PERSONAL_CODE, { lang }),
-            backURL: addSearchParams(getUrlWithTransactionIdAndSubmissionId(PrefixedUrls.INDIVIDUAL_PSC_LIST, req.params.transactionId, req.params.submissionId), { lang }),
+            currentUrl: addSearchParams(
+                getUrlWithTransactionIdAndSubmissionId(PrefixedUrls.PERSONAL_CODE, req.params.transactionId, req.params.submissionId),
+                { lang }),
+            backURL: addSearchParams(
+                getUrlWithTransactionIdAndSubmissionId(PrefixedUrls.INDIVIDUAL_PSC_LIST, req.params.transactionId, req.params.submissionId),
+                { lang }),
             templateName: Urls.PERSONAL_CODE,
             backLinkDataEvent: "personal-code-back-link"
         };

--- a/src/routers/handlers/psc-type/pscType.ts
+++ b/src/routers/handlers/psc-type/pscType.ts
@@ -21,15 +21,15 @@ export class PscTypeHandler extends GenericHandler<PscTypeViewData> {
             ...baseViewData,
             ...getLocaleInfo(locales, lang),
             title: "PSC type – Provide identity verification details for a PSC or relevant legal entity",
-            currentUrl: addSearchParams(
-                getUrlWithTransactionIdAndSubmissionId(PrefixedUrls.PSC_TYPE, req.params.transactionId, req.params.submissionId),
-                { companyNumber, lang }),
-            backURL: addSearchParams(
-                getUrlWithTransactionIdAndSubmissionId(PrefixedUrls.CONFIRM_COMPANY, req.params.transactionId, req.params.submissionId),
-                { companyNumber, lang }),
+            currentUrl: resolveUrlTemplate(PrefixedUrls.PSC_TYPE),
+            backURL: resolveUrlTemplate(PrefixedUrls.CONFIRM_COMPANY),
             templateName: Urls.PSC_TYPE,
             backLinkDataEvent: "psc-type-back-link"
         };
+
+        function resolveUrlTemplate (prefixedUrl: string): string | null {
+            return addSearchParams(getUrlWithTransactionIdAndSubmissionId(prefixedUrl, req.params.transactionId, req.params.submissionId), { companyNumber, lang });
+        }
     }
 
     public async executeGet (req: Request, res: Response): Promise<ViewModel<PscTypeViewData>> {

--- a/src/routers/handlers/psc-type/pscType.ts
+++ b/src/routers/handlers/psc-type/pscType.ts
@@ -2,8 +2,9 @@ import { Request, Response } from "express";
 import { PrefixedUrls, Urls } from "../../../constants";
 import { logger } from "../../../lib/logger";
 import { getLocaleInfo, getLocalesService, selectLang } from "../../../utils/localise";
-import { addSearchParams } from "../../../utils/queryParams";
 import { BaseViewData, GenericHandler, ViewModel } from "../generic";
+import { getUrlWithTransactionIdAndSubmissionId } from "../../../utils/url";
+import { addSearchParams } from "../../../utils/queryParams";
 interface PscTypeViewData extends BaseViewData { pscType: string }
 
 export class PscTypeHandler extends GenericHandler<PscTypeViewData> {
@@ -20,8 +21,12 @@ export class PscTypeHandler extends GenericHandler<PscTypeViewData> {
             ...baseViewData,
             ...getLocaleInfo(locales, lang),
             title: "PSC type – Provide identity verification details for a PSC or relevant legal entity",
-            currentUrl: addSearchParams(PrefixedUrls.PSC_TYPE, { lang }),
-            backURL: addSearchParams(PrefixedUrls.CONFIRM_COMPANY, { companyNumber, lang }),
+            currentUrl: addSearchParams(
+                getUrlWithTransactionIdAndSubmissionId(PrefixedUrls.PSC_TYPE, req.params.transactionId, req.params.submissionId),
+                { companyNumber, lang }),
+            backURL: addSearchParams(
+                getUrlWithTransactionIdAndSubmissionId(PrefixedUrls.CONFIRM_COMPANY, req.params.transactionId, req.params.submissionId),
+                { companyNumber, lang }),
             templateName: Urls.PSC_TYPE,
             backLinkDataEvent: "psc-type-back-link"
         };

--- a/src/routers/individualPscListRouter.ts
+++ b/src/routers/individualPscListRouter.ts
@@ -17,7 +17,7 @@ router.post("/", handleExceptions(async (req: Request, res: Response, _next: Nex
     const handler = new IndividualPscListHandler();
     await handler.executePost(req, res);
 
-    const lang = selectLang(req.body.lang);
+    const lang = selectLang(req.query.lang);
     const queryParams = new URLSearchParams(req.url.split("?")[1]);
     queryParams.set("lang", lang);
 

--- a/src/routers/individualStatementRouter.ts
+++ b/src/routers/individualStatementRouter.ts
@@ -19,7 +19,7 @@ router.post("/", handleExceptions(async (req: Request, res: Response, _next: Nex
     await handler.executePost(req, res);
 
     const nextPageUrl = getUrlWithTransactionIdAndSubmissionId(PrefixedUrls.PSC_VERIFIED, req.params.transactionId, req.params.submissionId);
-    const lang = selectLang(req.body.lang);
+    const lang = selectLang(req.query.lang);
     res.redirect(addSearchParams(nextPageUrl, { lang }));
 }));
 

--- a/src/routers/personalCodeRouter.ts
+++ b/src/routers/personalCodeRouter.ts
@@ -19,7 +19,7 @@ router.post("/", handleExceptions(async (req: Request, res: Response, _next: Nex
     await handler.executePost(req, res);
 
     const nextPageUrl = getUrlWithTransactionIdAndSubmissionId(PrefixedUrls.INDIVIDUAL_STATEMENT, req.params.transactionId, req.params.submissionId);
-    const lang = selectLang(req.body.lang);
+    const lang = selectLang(req.query.lang);
     res.redirect(addSearchParams(nextPageUrl, { lang }));
 }));
 

--- a/src/routers/pscTypeRouter.ts
+++ b/src/routers/pscTypeRouter.ts
@@ -17,7 +17,7 @@ router.get("/", handleExceptions(async (req: Request, res: Response, _next: Next
 }));
 
 router.post("/", handleExceptions(async (req: Request, res: Response, _next: NextFunction) => {
-    const lang = selectLang(req.body.lang);
+    const lang = selectLang(req.query.lang);
     const selectedType = req.body.pscType;
     const queryParams = new URLSearchParams(req.url.split("?")[1]);
 

--- a/test/routers/handlers/individual-statement/individualStatement.int.ts
+++ b/test/routers/handlers/individual-statement/individualStatement.int.ts
@@ -41,8 +41,8 @@ describe("individual statement view", () => {
         jest.clearAllMocks();
     });
 
-    it("Should render the Individual Statement page with a success status code, correct links, and correct statement selected", async () => {
-        const queryParams = new URLSearchParams("lang=en");
+    it.each(["en", "cy"])(`Should render the Individual Statement page with a success status code, correct (%s) links , and correct statement selected`, async (lang) => {
+        const queryParams = new URLSearchParams(`lang=${lang}`);
         const uriWithQuery = `${PrefixedUrls.INDIVIDUAL_STATEMENT}?${queryParams}`;
         const uri = getUrlWithTransactionIdAndSubmissionId(uriWithQuery, TRANSACTION_ID, PSC_VERIFICATION_ID);
 
@@ -51,11 +51,13 @@ describe("individual statement view", () => {
         const $ = cheerio.load(resp.text);
 
         expect(resp.status).toBe(HttpStatusCode.Ok);
-        expect($("a.govuk-back-link").attr("href")).toBe("/persons-with-significant-control-verification/transaction/11111-22222-33333/submission/662a0de6a2c6f9aead0f32ab/individual/personal-code?lang=en");
-        expect($("div#nameAndDateOfBirth").text()).toBe("Sir Forename Middlename Surname (Born April 2000)");
+        expect($("a.govuk-back-link").attr("href")).toBe(`/persons-with-significant-control-verification/transaction/11111-22222-33333/submission/662a0de6a2c6f9aead0f32ab/individual/personal-code?lang=${lang}`);
+        if (lang === "en") {
+            expect($("div#nameAndDateOfBirth").text()).toBe("Sir Forename Middlename Surname (Born April 2000)");
+            // expect emphasis applied to PSC name
+            expect(normalizeWhitespace($("label.govuk-checkboxes__label[for='psc_individual_statement']").html())).toBe("<label>I confirm that <strong>Sir Forename Middlename Surname</strong> has verified their identity.</label>");
+        }
         expect($("input.govuk-checkboxes__input[name=psc_individual_statement]").prop("checked")).toBe(true);
-        // expect emphasis applied to PSC name
-        expect(normalizeWhitespace($("label.govuk-checkboxes__label[for='psc_individual_statement']").html())).toBe("<label>I confirm that <strong>Sir Forename Middlename Surname</strong> has verified their identity.</label>");
     });
 
     it("Should redirect to the PSC verified page with a redirect status code", async () => {

--- a/test/routers/handlers/new-submission/newSubmissionHandler.int.ts
+++ b/test/routers/handlers/new-submission/newSubmissionHandler.int.ts
@@ -8,7 +8,6 @@ import { postTransaction } from "../../../../src/services/transactionService";
 import { createPscVerification } from "../../../../src/services/pscVerificationService";
 import { COMPANY_NUMBER, CREATED_RESOURCE, PSC_VERIFICATION_ID } from "../../../mocks/pscVerification.mock";
 import { CREATED_PSC_TRANSACTION, TRANSACTION_ID } from "../../../mocks/transaction.mock";
-import { addSearchParams } from "../../../../src/utils/queryParams";
 
 jest.mock("../../../../src/services/transactionService");
 const mockPostTransaction = postTransaction as jest.Mock;
@@ -22,9 +21,6 @@ mockCreatePscVerification.mockResolvedValue({
     resource: CREATED_RESOURCE
 });
 
-const lang = "en";
-const createNewSubmissionUrl: string = addSearchParams(PrefixedUrls.NEW_SUBMISSION, { COMPANY_NUMBER, lang });
-
 describe("new submission handler tests", () => {
 
     beforeEach(() => {
@@ -37,13 +33,13 @@ describe("new submission handler tests", () => {
     });
 
     it("Should redirect with a temporary redirect status code", async () => {
-        const response = await request(app).get(createNewSubmissionUrl).expect(HttpStatusCode.Found);
+        const response = await request(app).get(PrefixedUrls.NEW_SUBMISSION).expect(HttpStatusCode.Found);
     });
 
-    it("Should redirect to the psc_type screen", async () => {
-        const expectedRedirectUrl = `/persons-with-significant-control-verification/transaction/${TRANSACTION_ID}/submission/${PSC_VERIFICATION_ID}/psc-type?companyNumber=${COMPANY_NUMBER}&lang=en`;
-        await request(app).get(createNewSubmissionUrl)
-            .query({ companyNumber: `${COMPANY_NUMBER}`, lang: "en" })
+    it.each(["en", "cy"])("Should redirect to the psc_type screen with lang query set to %s", async (lang) => {
+        const expectedRedirectUrl = `/persons-with-significant-control-verification/transaction/${TRANSACTION_ID}/submission/${PSC_VERIFICATION_ID}/psc-type?companyNumber=${COMPANY_NUMBER}&lang=${lang}`;
+        await request(app).get(PrefixedUrls.NEW_SUBMISSION)
+            .query({ companyNumber: `${COMPANY_NUMBER}`, lang: lang })
             .expect("Location", expectedRedirectUrl);
     });
 });


### PR DESCRIPTION
- Set the transaction id, submission id and lang values correctly and pass them around so that language switching works
  - can go back and forth between languages on each page
  - can progress through journey and retain language
  - language retained from the links on the Confirmation page too
- unit tests

IDVA3-1499
IDVA3-1189 - no change done for this, but please see my comment on the story.