### PR TITLE
Replace favicon with version in govuk v4.6.0

### DIFF
--- a/src/views/partials/__meta_header.njk
+++ b/src/views/partials/__meta_header.njk
@@ -6,9 +6,9 @@
     <title>{{ title }}</title>
     <link href="{{ cdnHost }}/stylesheets/govuk-frontend/v4.6.0/govuk-frontend-4.6.0.min.css" rel="stylesheet"/>
     <link href="{{ cdnHost }}/stylesheets/services/presenter-account/application.css" rel="stylesheet"/>
-    <link href="{{cdnHost}}/stylesheets/extensions/languages-nav.css" rel="stylesheet"/>
+    <link href="{{ cdnHost }}/stylesheets/extensions/languages-nav.css" rel="stylesheet"/>
     <link href="{{ cdnUrlCss }}/app.min.css" media="all" rel="stylesheet" type="text/css" />
-    <link href="{{ cdnHost }}/images/favicon.ico" rel="icon" type="image/x-icon" />
+    <link href="{{ cdnHost }}/images/govuk-frontend/v4.6.0/images/favicon.ico" rel="icon" type="image/x-icon" />
     {% include "partials/__styles.njk" %}
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     {# <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" /> #}


### PR DESCRIPTION
<img width="538" alt="Screenshot 2024-06-07 at 2 01 10 PM" src="https://github.com/companieshouse/psc-verification-web/assets/2736331/9b262276-10b0-46d5-94d0-95173d30db65">

IDVA3-1502