### PR TITLE
Pass company Name in Transaction Resource.  

### DIFF
--- a/src/services/transactionService.ts
+++ b/src/services/transactionService.ts
@@ -1,11 +1,13 @@
 import { Resource } from "@companieshouse/api-sdk-node";
 import ApiClient from "@companieshouse/api-sdk-node/dist/client";
+import { CompanyProfile } from "@companieshouse/api-sdk-node/dist/services/company-profile/types";
 import { ApiErrorResponse, ApiResponse } from "@companieshouse/api-sdk-node/dist/services/resource";
 import { Transaction } from "@companieshouse/api-sdk-node/dist/services/transaction/types";
 import { Request } from "express";
 import { StatusCodes } from "http-status-codes";
 import { logger } from "../lib/logger";
 import { createOAuthApiClient } from "./apiClientService";
+import { getCompanyProfile } from "./companyProfileService";
 
 export const REFERENCE = "PscVerificationReference";
 export const DESCRIPTION = "PSC Verification Transaction";
@@ -14,11 +16,14 @@ export enum TransactionStatus { OPEN = "open", CLOSED = "closed" }
 export const postTransaction = async (req: Request): Promise<Transaction> => {
 
     const companyNumber = req.query.companyNumber as string;
+    const companyProfile: CompanyProfile = await getCompanyProfile(req, companyNumber);
+    const companyName: string = companyProfile.companyName;
     const oAuthApiClient = createOAuthApiClient(req.session);
 
     const transaction: Transaction = {
         reference: REFERENCE,
-        description: DESCRIPTION
+        description: DESCRIPTION,
+        companyName: companyName
     };
 
     logger.debug(`${postTransaction.name} - Creating transaction with company number ${companyNumber}`);

--- a/test/mocks/transaction.mock.ts
+++ b/test/mocks/transaction.mock.ts
@@ -3,12 +3,14 @@ import { DESCRIPTION, REFERENCE, TransactionStatus } from "../../src/services/tr
 
 export const TRANSACTION_ID = "11111-22222-33333";
 export const COMPANY_NUMBER = "12345678";
+export const COMPANY_NAME = "Test 123 Ltd";
 export const PSC_VERIFICATION_ID = "662a0de6a2c6f9aead0f32ab";
 
 export const CREATED_PSC_TRANSACTION = {
     id: TRANSACTION_ID,
     reference: REFERENCE,
-    description: DESCRIPTION
+    description: DESCRIPTION,
+    companyName: COMPANY_NAME
 } as Transaction;
 
 export const OPEN_PSC_TRANSACTION = {

--- a/test/services/transactionService.unit.ts
+++ b/test/services/transactionService.unit.ts
@@ -3,11 +3,16 @@ import { Transaction } from "@companieshouse/api-sdk-node/dist/services/transact
 import { HttpStatusCode } from "axios";
 import { Request } from "express";
 import { createOAuthApiClient } from "../../src/services/apiClientService";
+import { getCompanyProfile } from "../../src/services/companyProfileService";
 import { DESCRIPTION, TransactionStatus, closeTransaction, postTransaction, putTransaction } from "../../src/services/transactionService";
+import { validCompanyProfile } from "../mocks/companyProfile.mock";
 import { CLOSED_PSC_TRANSACTION, COMPANY_NUMBER, CREATED_PSC_TRANSACTION, OPEN_PSC_TRANSACTION, PSC_VERIFICATION_ID, TRANSACTION_ID } from "../mocks/transaction.mock";
 
 jest.mock("@companieshouse/api-sdk-node");
 jest.mock("../../src/services/apiClientService");
+jest.mock("../../src/services/companyProfileService");
+const mockGetCompanyProfile = getCompanyProfile as jest.Mock;
+mockGetCompanyProfile.mockResolvedValue(validCompanyProfile);
 
 const mockCreateOAuthApiClient = createOAuthApiClient as jest.Mock;
 const mockPostTransaction = jest.fn();


### PR DESCRIPTION
Company Number not allowed for a User Transaction, but the name will get passed to the Confirmation Email 

IDVA3-1566

```
{
    "_id" : "094785-968417-186120",
    "data" : {
        "_id" : "094785-968417-186120",
        "company_name" : "THE GIRLS' DAY SCHOOL TRUST",
        "created_at" : ISODate("2024-06-17T08:14:55.000Z"),
        "created_by" : {
            "language" : "en",
            "id" : "Y2VkZWVlMzhlZWFjY2M4MzQ3MT",
            "email" : "demo@ch.gov.uk"
        },
        "updated_at" : ISODate("2024-06-17T08:14:55.000Z"),
        "description" : "PSC Verification Transaction",
        "etag" : "aea61aad1995657c8856770e8bbc4b2376aa100f",
        "links" : {
            "self" : "/transactions/094785-968417-186120"
        },
        "reference" : "PscVerificationReference",
        "resources" : {
            "/transactions/094785-968417-186120/persons-with-significant-control-verification/666ff081c59a4550ef024cf7" : {
```