### PR TITLE
Simplify start test and make it actually check the view data returned

### DIFF
--- a/src/routers/handlers/start/startHandler.ts
+++ b/src/routers/handlers/start/startHandler.ts
@@ -25,7 +25,6 @@ export class StartHandler extends GenericHandler<StartViewData> {
             ...baseViewData,
             ...getLocaleInfo(locales, lang),
             isSignedIn: false,
-            title: "PSC Verification",
             idvImplementationDate: internationaliseDate(idvDateFormatted, lang),
             currentUrl: addSearchParams(PrefixedUrls.START, { lang }),
             backURL: null,

--- a/test/routers/handlers/start/start.unit.ts
+++ b/test/routers/handlers/start/start.unit.ts
@@ -5,7 +5,7 @@ import { Urls } from "../../../../src/constants";
 describe("start handler", () => {
     describe("executeGet", () => {
 
-        it("should return the correct template path", async () => {
+        it("should return the correct template path and view data", async () => {
             const req = httpMocks.createRequest({
                 method: "GET",
                 url: Urls.START
@@ -17,24 +17,8 @@ describe("start handler", () => {
             const { templatePath, viewData } = await handler.executeGet(req, res);
 
             expect(templatePath).toBe("router_views/start/start");
-        });
-        it("should return the correct view data", async () => {
-            const req = httpMocks.createRequest({
-                method: "GET",
-                url: Urls.START
-            });
-
-            const res = httpMocks.createResponse({});
-            const handler = new StartHandler();
-
-            const { templatePath, viewData } = await handler.executeGet(req, res);
-
-            expect.objectContaining({
-                title: "PSC Verification",
-                currentUrl: "/persons-with-significant-control-verification/start?lang=en",
-                idvImplementationDate: "1 September 2025"
-            });
-
+            expect(viewData.currentUrl).toBe("/persons-with-significant-control-verification/start?lang=en");
+            expect(viewData.idvImplementationDate).toBe("1 September 2025");
         });
     });
 });


### PR DESCRIPTION
- title value passed in View data not used in template, so removing
- the 2nd test wasn't actually checking anything, so fixing that and simplifying the test