### PR TITLE
Fix sonar issue 'shadowed variable'

### DIFF
--- a/src/routers/handlers/psc-type/pscTypeHandler.ts
+++ b/src/routers/handlers/psc-type/pscTypeHandler.ts
@@ -29,9 +29,9 @@ export class PscTypeHandler extends GenericHandler<PscTypeViewData> {
             backLinkDataEvent: "psc-type-back-link"
         };
 
-        function resolveUrlTemplate (prefixedUrl: string, companyNumber?: string): string | null {
+        function resolveUrlTemplate (prefixedUrl: string, companyNum?: string): string | null {
             const query = { lang, pscType };
-            return addSearchParams(getUrlWithTransactionIdAndSubmissionId(prefixedUrl, req.params.transactionId, req.params.submissionId), companyNumber ? { companyNumber, ...query } : query);
+            return addSearchParams(getUrlWithTransactionIdAndSubmissionId(prefixedUrl, req.params.transactionId, req.params.submissionId), companyNum ? { companyNumber: companyNum, ...query } : query);
         }
     }
 


### PR DESCRIPTION
- rename a function parameter to avoid shadowing 'companyNumber' variable