### PR TITLE
Add page for Service not live based on config flag

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -6,8 +6,10 @@ import { ExternalUrls, servicePathPrefix } from "./constants";
 import { logger } from "./lib/logger";
 import { sessionMiddleware } from "./middleware/session";
 import routerDispatch from "./routerDispatch";
+import { isLive } from "./middleware/serviceLive";
 
 const app = express();
+app.use(isLive);
 
 app.set("views", [
     path.join(__dirname, "views"),

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -135,6 +135,9 @@ export const env = readEnv(process.env, {
         .describe("Link to policies")
         .default("https://resources.companieshouse.gov.uk/legal/termsAndConditions.shtml"),
     PORT: port.describe("Port to run the web server on").default(3000),
+    SERVICE_LIVE: str
+        .describe("Prevent use of service until Implementation")
+        .default("false"),
     VERIFY_IDENTITY_LINK: str
         .describe("Path to guidance to Verify Identity")
         .default("")

--- a/src/middleware/serviceLive.ts
+++ b/src/middleware/serviceLive.ts
@@ -1,0 +1,11 @@
+import { NextFunction, Request, Response } from "express";
+import { env } from "../config";
+
+export const isLive = (req: Request, res: Response, next: NextFunction) => {
+
+    if (env.SERVICE_LIVE !== "true") {
+        res.render("router_views/serviceNotLive/serviceNotLive");
+    } else {
+        next();
+    }
+};

--- a/src/views/router_views/serviceNotLive/serviceNotLive.njk
+++ b/src/views/router_views/serviceNotLive/serviceNotLive.njk
@@ -1,0 +1,6 @@
+{% extends "layouts/default.njk" %}
+
+{% block main_content %}
+    <h1 class="govuk-heading-l">Provide identity verification details for a PSC or relevant legal entity</h1>
+    <p class="govuk-body">This service is not yet available</p>
+{% endblock %}

--- a/test/app.int.ts
+++ b/test/app.int.ts
@@ -1,0 +1,52 @@
+import { HttpStatusCode } from "axios";
+import * as cheerio from "cheerio";
+import request from "supertest";
+import app from "../src/app";
+import * as config from "../src/config";
+import { servicePathPrefix } from "../src/constants";
+
+jest.mock("ioredis");
+jest.mock("../src/config", () => ({
+    env: {
+        SERVICE_LIVE: null,
+        COOKIE_DOMAIN: "chs.local",
+        COOKIE_NAME: "__SID",
+        COOKIE_SECRET: "123456789012345678901234",
+        LOG_LEVEL: "debug",
+        DEFAULT_SESSION_EXPIRATION: "3600",
+        CACHE_SERVER: "cache_server",
+        IDV_IMPLEMENTATION_DATE: "20250901"
+    }
+}));
+
+const mockConfig = config as { env: {
+    SERVICE_LIVE: string,
+    COOKIE_DOMAIN: string,
+    COOKIE_NAME: string,
+    COOKIE_SECRET: string,
+    LOG_LEVEL: string,
+    DEFAULT_SESSION_EXPIRATION: string,
+    CACHE_SERVER: string,
+    IDV_IMPLEMENTATION_DATE: string
+}};
+
+describe("Service not live integration tests", () => {
+
+    it("should render the Service not live page when SERVICE_LEVEL is false", async () => {
+        mockConfig.env.SERVICE_LIVE = "false";
+        const resp = await request(app).get(servicePathPrefix);
+
+        expect(resp.status).toBe(HttpStatusCode.Ok);
+        const $ = cheerio.load(resp.text);
+        expect($("p.govuk-body").text()).toMatch("This service is not yet available");
+    });
+
+    it("should render the Start page when SERVICE_LEVEL is true", async () => {
+        mockConfig.env.SERVICE_LIVE = "true";
+        const resp = await request(app).get(servicePathPrefix);
+
+        expect(resp.status).toBe(HttpStatusCode.Ok);
+        const $ = cheerio.load(resp.text);
+        expect($("p.govuk-body").text()).toContain("Use this service");
+    });
+});

--- a/test/global.setup.ts
+++ b/test/global.setup.ts
@@ -12,4 +12,5 @@ export default () => {
     process.env.LOG_LEVEL = "DEBUG";
     process.env.NUNJUCKS_LOADER_WATCH = "false";
     process.env.IDV_IMPLEMENTATION_DATE = "20250901";
+    process.env.SERVICE_LIVE = "true";
 };


### PR DESCRIPTION
This is not the Service Maintenance functionality based on a call to the API.  Rather it is a block to any use until the service is 'live and available to customers'

<img width="770" alt="Screenshot 2024-07-23 at 8 35 29 AM" src="https://github.com/user-attachments/assets/b0f60800-d058-4e93-b80e-00f9abbd5256">

Config PR's:
- https://github.com/companieshouse/docker-chs-development/pull/1266
- https://github.com/companieshouse/ecs-service-configs-dev/pull/535

IDVA3-1853