### PR TITLE
Add the company number param to the current Url 

### DIFF
--- a/src/routers/handlers/stop-screen/stopScreenHandler.ts
+++ b/src/routers/handlers/stop-screen/stopScreenHandler.ts
@@ -45,7 +45,7 @@ const setContent = async (req: Request, stopType: STOP_TYPE, baseViewData: BaseV
                 ...baseViewData,
                 ...getLocaleInfo(locales, lang),
                 templateName: stopType,
-                currentUrl: resolveUrlTemplate(stopScreenPrefixedUrl, stopType),
+                currentUrl: addSearchParams(getUrlWithStopType(stopScreenPrefixedUrl, stopType), { companyNumber, lang }),
                 backURL: addSearchParams(PrefixedUrls.CONFIRM_COMPANY, { companyNumber, lang }),
                 backLinkDataEvent: "super-secure-back-link",
                 extraData: [env.DSR_EMAIL_ADDRESS, env.DSR_PHONE_NUMBER]

--- a/test/routers/handlers/stop-screen/stopScreenHandler.unit.ts
+++ b/test/routers/handlers/stop-screen/stopScreenHandler.unit.ts
@@ -68,7 +68,7 @@ describe("Stop screen handler", () => {
                 case STOP_TYPE.SUPER_SECURE:
                     expect(viewData).toMatchObject({
                         ...expectedViewData,
-                        currentUrl: `/persons-with-significant-control-verification/stop/${stopType}?lang=en`,
+                        currentUrl: `/persons-with-significant-control-verification/stop/${stopType}?companyNumber=00006400&lang=en`,
                         backURL: `${PrefixedUrls.CONFIRM_COMPANY}?companyNumber=00006400&lang=en`,
                         extraData: [env.DSR_EMAIL_ADDRESS, env.DSR_PHONE_NUMBER]
                     });


### PR DESCRIPTION
This is to fix a bug, where the company number param was lost from the Url when toggling the language links

IDVA3-2522