### PR TITLE
Add template and handling for company status stop screen

### DIFF
--- a/locales/cy/stop-screens.json
+++ b/locales/cy/stop-screens.json
@@ -1,4 +1,12 @@
 {
+  "company_status_main_title": "to be translated",
+  "company_status_main_heading": "to be translated",
+  "company_status_statement_1": "to be translated",
+  "company_status_statement_2": "to be translated",
+  "company_status_wrong_company_action": "to be translated",
+  "company_status_wrong_company_action_text": "to be translated",
+  "company_status_contact_us_text": "to be translated",
+  "company_status_contact_us": "to be translated",
   "company_type_main_title": "to be translated",
   "company_type_main_heading": "to be translated",
   "company_type_intro_start": "to be translated",

--- a/locales/en/stop-screens.json
+++ b/locales/en/stop-screens.json
@@ -1,4 +1,12 @@
 {
+  "company_status_main_title": "You cannot provide verification details for this company through this service",
+  "company_status_main_heading": "Companies that are dissolved or converted closed cannot use this service",
+  "company_status_statement_1": "'s status on the Companies House register is currently either dissolved or converted closed.",
+  "company_status_statement_2": "This means its PSCs do not need to provide their verification details.",
+  "company_status_wrong_company_action": "If this is the wrong company, ",
+  "company_status_wrong_company_action_text": "go back and enter a different company number",
+  "company_status_contact_us_text": "Contact us",
+  "company_status_contact_us": "if you have any questions.",
   "company_type_main_title": "You cannot provide verification details for this company through this service",
   "company_type_main_heading": "Only certain company types can use this service",
   "company_type_intro_start": "You can only provide verification details for PSCs of",

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     },
     "nodemonConfig": {
         "watch": [
+            "./locales",
             "./src",
             "./assets/src"
         ],

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,6 +2,7 @@ export const servicePathPrefix = "/persons-with-significant-control-verification
 const urlWithTransactionIdAndSubmissionId = "/transaction/:transactionId/submission/:submissionId";
 
 export enum STOP_TYPE {
+    COMPANY_STATUS = "company-status",
     COMPANY_TYPE = "company-type",
     PSC_DOB_MISMATCH = "psc-dob-mismatch",
     RP01_GUIDANCE = "rp01-guidance",

--- a/src/routers/handlers/stop-screen/stopScreenHandler.ts
+++ b/src/routers/handlers/stop-screen/stopScreenHandler.ts
@@ -42,6 +42,16 @@ const setContent = async (req: Request, res: Response, stopType: STOP_TYPE, base
     const stopScreenPrefixedUrl = toStopScreenPrefixedUrl(stopType);
 
     switch (stopType) {
+        case STOP_TYPE.COMPANY_STATUS:
+            return {
+                ...baseViewData,
+                ...getLocaleInfo(locales, lang),
+                templateName: stopType,
+                currentUrl: addSearchParams(getUrlWithStopType(stopScreenPrefixedUrl, stopType), { companyNumber, lang }),
+                backURL: addSearchParams(resolveUrlTemplate(PrefixedUrls.CONFIRM_COMPANY), { companyNumber }),
+                backLinkDataEvent: "company-status-back-link",
+                extraData: [companyName, resolveUrlTemplate(PrefixedUrls.COMPANY_NUMBER), env.CONTACT_US_LINK]
+            };
         case STOP_TYPE.COMPANY_TYPE:
             return {
                 ...baseViewData,

--- a/src/views/router_views/stop_screen/company-status.njk
+++ b/src/views/router_views/stop_screen/company-status.njk
@@ -1,0 +1,19 @@
+{% set title = i18n.company_status_main_title %}
+
+{% extends "layouts/default.njk" %}
+
+{% block main_content %}
+
+    <h1 class="govuk-heading-l">{{ i18n.company_status_main_heading }}</h1>
+
+    <p class="govuk-body">{{ extraData[0] }}{{ i18n.company_status_statement_1 }}</p>
+    <p class="govuk-body">{{ i18n.company_status_statement_2 }}</p>
+    <p class="govuk-body">{{ i18n.company_status_wrong_company_action }}
+        <a id="go-back-enter-number" href="{{ extraData[1] }}">{{ i18n.company_status_wrong_company_action_text -}}</a>.
+    </p>
+    <p class="govuk-body">
+        <a id="contact-us" href="{{ extraData[2] }}">{{ i18n.company_status_contact_us_text -}}</a>
+        {{ i18n.company_status_contact_us }}
+    </p>
+
+{% endblock %}

--- a/test/routers/handlers/stop-screen/stopScreen.int.ts
+++ b/test/routers/handlers/stop-screen/stopScreen.int.ts
@@ -65,6 +65,11 @@ describe("stop screen view tests", () => {
         expect(resp.status).toBe(HttpStatusCode.Ok);
 
         switch (stopType) {
+            case STOP_TYPE.COMPANY_STATUS:
+                expect($("a.govuk-back-link").attr("href")).toBe(`${PrefixedUrls.CONFIRM_COMPANY}?lang=en&companyNumber=00006400`);
+                expect($("a#go-back-enter-number").attr("href")).toBe(`${PrefixedUrls.COMPANY_NUMBER}?lang=en`);
+                expect($("a#contact-us").attr("href")).toBe(env.CONTACT_US_LINK);
+                break;
             case STOP_TYPE.COMPANY_TYPE:
                 expect($("a.govuk-back-link").attr("href")).toBe(`${PrefixedUrls.CONFIRM_COMPANY}?lang=en&companyNumber=00006400`);
                 expect($("a#go-back-enter-number").attr("href")).toBe(`${PrefixedUrls.COMPANY_NUMBER}?lang=en`);

--- a/test/routers/handlers/stop-screen/stopScreenHandler.unit.ts
+++ b/test/routers/handlers/stop-screen/stopScreenHandler.unit.ts
@@ -67,6 +67,15 @@ describe("Stop screen handler", () => {
             };
 
             switch (stopType) {
+                case STOP_TYPE.COMPANY_STATUS:
+                    expect(viewData).toMatchObject(
+                        {
+                            ...expectedViewData,
+                            currentUrl: `/persons-with-significant-control-verification/stop/${stopType}?companyNumber=00006400&lang=en`,
+                            backURL: `${PrefixedUrls.CONFIRM_COMPANY}?lang=en&companyNumber=00006400`,
+                            extraData: [validCompanyProfile.companyName, `${PrefixedUrls.COMPANY_NUMBER}?lang=en`, env.CONTACT_US_LINK]
+                        });
+                    break;
                 case STOP_TYPE.COMPANY_TYPE:
                     expect(viewData).toMatchObject(
                         {


### PR DESCRIPTION
Standard stop screen - template and control, but not the validation/navigation to it yet, which is a later story

> [!NOTE]  
> I've added the `/locales` directory to the nodemon config - good idea?

IDVA3-2458

<img width="1091" alt="Screenshot 2024-12-06 at 8 41 30 AM" src="https://github.com/user-attachments/assets/80cc743c-62e8-4977-9e24-8af6f31ec1af">
