### PR TITLE
Improve handling unexpected errors

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -69,14 +69,14 @@ njk.addGlobal("verifyIdentityLink", process.env.VERIFY_IDENTITY_LINK);
 // if app is behind a front-facing proxy, and to use the X-Forwarded-* headers to determine the connection and the IP address of the client
 app.enable("trust proxy");
 
+// channel all requests through router dispatch
+routerDispatch(app);
+
 // unhandled errors
 app.use((err: any, req: Request, res: Response, next: NextFunction) => {
     logger.error(`${err.name} - appError: ${err.message} - ${err.stack}`);
     res.render("partials/error_500");
 });
-
-// channel all requests through router dispatch
-routerDispatch(app);
 
 // unhandled exceptions
 process.on("uncaughtException", (err: any) => {

--- a/src/routers/handlers/start/startHandler.ts
+++ b/src/routers/handlers/start/startHandler.ts
@@ -9,7 +9,7 @@ import { env } from "../../../config";
 
 interface StartViewData extends BaseViewData {idvImplementationDate: string}
 
-export class StartHandler extends GenericHandler<StartViewData> {
+export default class StartHandler extends GenericHandler<StartViewData> {
 
     public static templatePath = "router_views/start/start";
 

--- a/src/routers/startRouter.ts
+++ b/src/routers/startRouter.ts
@@ -1,6 +1,6 @@
 import { NextFunction, Request, Response, Router } from "express";
 import { handleExceptions } from "../utils/asyncHandler";
-import { StartHandler } from "./handlers/start/startHandler";
+import StartHandler from "./handlers/start/startHandler";
 
 const startRouter: Router = Router();
 

--- a/test/app.errors.int.ts
+++ b/test/app.errors.int.ts
@@ -1,0 +1,68 @@
+import { HttpStatusCode } from "axios";
+import * as cheerio from "cheerio";
+import request from "supertest";
+import app from "../src/app";
+import * as config from "../src/config";
+import { servicePathPrefix } from "../src/constants";
+
+jest.mock("ioredis");
+jest.mock("../src/config", () => ({
+    env: {
+        SERVICE_LIVE: null,
+        COOKIE_DOMAIN: "chs.local",
+        COOKIE_NAME: "__SID",
+        COOKIE_SECRET: "123456789012345678901234",
+        LOG_LEVEL: "debug",
+        DEFAULT_SESSION_EXPIRATION: "3600",
+        CACHE_SERVER: "cache_server",
+        IDV_IMPLEMENTATION_DATE: "20250901"
+    }
+}));
+
+const mockConfig = config as {
+    env: {
+        SERVICE_LIVE: string,
+        COOKIE_DOMAIN: string,
+        COOKIE_NAME: string,
+        COOKIE_SECRET: string,
+        LOG_LEVEL: string,
+        DEFAULT_SESSION_EXPIRATION: string,
+        CACHE_SERVER: string,
+        IDV_IMPLEMENTATION_DATE: string
+    }
+};
+
+const mockStartHandlerGet = jest.fn();
+
+jest.mock("../src/routers/handlers/start/startHandler", () => {
+    return jest.fn().mockImplementation(() => ({
+        executeGet: mockStartHandlerGet
+    }));
+});
+
+describe("Service unexpected Error handling", () => {
+
+    it("should show 'Service Error' page when an async Promise is rejected", async () => {
+        mockConfig.env.SERVICE_LIVE = "true";
+        mockStartHandlerGet.mockRejectedValueOnce("GET failed (async)");
+
+        const resp = await request(app).get(servicePathPrefix);
+
+        expect(resp.status).toBe(HttpStatusCode.Ok);
+        const $ = cheerio.load(resp.text);
+        expect($("h1.govuk-heading-xl").text()).toContain("Internal server error");
+    });
+
+    it("should show 'Service Error' page when a sync Error is thrown", async () => {
+        mockConfig.env.SERVICE_LIVE = "true";
+        mockStartHandlerGet.mockImplementation(() => {
+            throw new Error("GET failed (sync)");
+        });
+
+        const resp = await request(app).get(servicePathPrefix);
+
+        expect(resp.status).toBe(HttpStatusCode.Ok);
+        const $ = cheerio.load(resp.text);
+        expect($("h1.govuk-heading-xl").text()).toContain("Internal server error");
+    });
+});

--- a/test/routers/handlers/start/start.unit.ts
+++ b/test/routers/handlers/start/start.unit.ts
@@ -1,5 +1,5 @@
 import * as httpMocks from "node-mocks-http";
-import { StartHandler } from "../../../../src/routers/handlers/start/startHandler";
+import StartHandler from "../../../../src/routers/handlers/start/startHandler";
 import { Urls } from "../../../../src/constants";
 
 describe("start handler", () => {


### PR DESCRIPTION
- move app.ts error handling code after routerDispatch call
- add integration tests for errors
- default export StartHandler (easier mocking)