### PR TITLE
Add exclusively super secure stop screen validation/routing

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,6 +9,11 @@ export enum STOP_TYPE {
     SUPER_SECURE = "super-secure"
 };
 
+export enum PSC_KIND_TYPE {
+    INDIVIDUAL = "individual-person-with-significant-control",
+    SUPER_SECURE = "super-secure-person-with-significant-control"
+}
+
 export function toStopScreenUrl (stopType: STOP_TYPE) {
     switch (stopType) {
         case STOP_TYPE.PSC_DOB_MISMATCH:

--- a/src/routers/handlers/individual-psc-list/individualPscListHandler.ts
+++ b/src/routers/handlers/individual-psc-list/individualPscListHandler.ts
@@ -11,8 +11,9 @@ import { logger } from "../../../lib/logger";
 
 interface PscListData {
     pscId: string,
-    pscName: string,
-    pscDob: string,
+    pscKind?: string,
+    pscName?: string,
+    pscDob?: string,
     pscVerificationDeadlineDate: string
 }
 
@@ -22,6 +23,7 @@ interface IndividualPscListViewData extends BaseViewData {
     dsrEmailAddress: string,
     dsrPhoneNumber: string,
     pscDetails: PscListData[],
+    exclusivelySuperSecure: boolean,
     selectedPscId: string | null,
     nextPageUrl: string | null
 }
@@ -54,6 +56,8 @@ export class IndividualPscListHandler extends GenericHandler<IndividualPscListVi
             individualPscList = await getCompanyIndividualPscList(req, companyNumber);
         }
 
+        const pscDetails = this.getViewPscDetails(individualPscList, lang);
+
         return {
             ...baseViewData,
             ...getLocaleInfo(locales, lang),
@@ -64,7 +68,8 @@ export class IndividualPscListHandler extends GenericHandler<IndividualPscListVi
             confirmationStatementDate,
             dsrEmailAddress,
             dsrPhoneNumber,
-            pscDetails: this.getViewPscDetails(individualPscList, lang),
+            pscDetails,
+            exclusivelySuperSecure: pscDetails.every((psc) => psc.pscKind?.startsWith("super-secure-person")),
             templateName: Urls.INDIVIDUAL_PSC_LIST,
             backLinkDataEvent: "psc-list-back-link"
         };
@@ -90,6 +95,7 @@ export class IndividualPscListHandler extends GenericHandler<IndividualPscListVi
 
             return {
                 pscId: psc.links.self.split("/").pop() as string,
+                pscKind: psc.kind,
                 pscName: psc.name,
                 pscDob: pscFormattedDob,
                 pscVerificationDeadlineDate: "[pscVerificationDate]"

--- a/src/routers/handlers/individual-psc-list/individualPscListHandler.ts
+++ b/src/routers/handlers/individual-psc-list/individualPscListHandler.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from "express";
 import { CompanyPersonWithSignificantControl } from "@companieshouse/api-sdk-node/dist/services/company-psc/types";
 import { getCompanyIndividualPscList } from "../../../services/companyPscService";
-import { PrefixedUrls, Urls } from "../../../constants";
+import { PSC_KIND_TYPE, PrefixedUrls, Urls } from "../../../constants";
 import { getLocaleInfo, getLocalesService, selectLang } from "../../../utils/localise";
 import { addSearchParams } from "../../../utils/queryParams";
 import { BaseViewData, GenericHandler, ViewModel } from "../generic";
@@ -56,7 +56,7 @@ export class IndividualPscListHandler extends GenericHandler<IndividualPscListVi
             individualPscList = await getCompanyIndividualPscList(req, companyNumber);
         }
 
-        const pscDetails = this.getViewPscDetails(individualPscList, lang);
+        const allPscDetails = this.getViewPscDetails(individualPscList, lang);
 
         return {
             ...baseViewData,
@@ -68,8 +68,8 @@ export class IndividualPscListHandler extends GenericHandler<IndividualPscListVi
             confirmationStatementDate,
             dsrEmailAddress,
             dsrPhoneNumber,
-            pscDetails,
-            exclusivelySuperSecure: pscDetails.every((psc) => psc.pscKind?.startsWith("super-secure-person")),
+            pscDetails: allPscDetails.filter(psc => psc.pscKind === PSC_KIND_TYPE.INDIVIDUAL),
+            exclusivelySuperSecure: allPscDetails.every((psc) => psc.pscKind === PSC_KIND_TYPE.SUPER_SECURE),
             templateName: Urls.INDIVIDUAL_PSC_LIST,
             backLinkDataEvent: "psc-list-back-link"
         };

--- a/src/routers/individualPscListRouter.ts
+++ b/src/routers/individualPscListRouter.ts
@@ -1,13 +1,27 @@
+import { CompanyProfile } from "@companieshouse/api-sdk-node/dist/services/company-profile/types";
 import { NextFunction, Request, Response, Router } from "express";
+import { PrefixedUrls, STOP_TYPE } from "../constants";
 import { handleExceptions } from "../utils/asyncHandler";
+import { addSearchParams } from "../utils/queryParams";
+import { logger } from "../lib/logger";
+import { getUrlWithStopType } from "../utils/url";
 import { IndividualPscListHandler } from "./handlers/individual-psc-list/individualPscListHandler";
 
 const individualPscListRouter: Router = Router({ mergeParams: true });
 
 individualPscListRouter.get("/", handleExceptions(async (req: Request, res: Response, _next: NextFunction) => {
     const handler = new IndividualPscListHandler();
+    const companyProfile: CompanyProfile = res.locals?.companyProfile;
+    const companyNumber = companyProfile.companyNumber;
+    const lang = req.query.lang as string;
     const { templatePath, viewData } = await handler.executeGet(req, res);
-    res.render(templatePath, viewData);
+
+    if (viewData.exclusivelySuperSecure) {
+        logger.debug(`individualPscListRouter.get - PSCs are exclusively Super Secure for company number ${companyNumber}: paper filing is required`);
+        res.redirect(addSearchParams(getUrlWithStopType(PrefixedUrls.STOP_SCREEN, STOP_TYPE.SUPER_SECURE), { companyNumber, lang }));
+    } else {
+        res.render(templatePath, viewData);
+    };
 }));
 
 export default individualPscListRouter;

--- a/src/routers/individualPscListRouter.ts
+++ b/src/routers/individualPscListRouter.ts
@@ -21,7 +21,7 @@ individualPscListRouter.get("/", handleExceptions(async (req: Request, res: Resp
         res.redirect(addSearchParams(getUrlWithStopType(PrefixedUrls.STOP_SCREEN, STOP_TYPE.SUPER_SECURE), { companyNumber, lang }));
     } else {
         res.render(templatePath, viewData);
-    };
+    }
 }));
 
 export default individualPscListRouter;

--- a/src/services/companyPscService.ts
+++ b/src/services/companyPscService.ts
@@ -6,10 +6,9 @@ import { createAndLogError, logger } from "../lib/logger";
 import { createOAuthApiClient } from "./apiClientService";
 import { ApiErrorResponse } from "@companieshouse/api-sdk-node/dist/services/resource";
 import { HttpStatusCode } from "axios";
+import { PSC_KIND_TYPE } from "../constants";
 
 export const getCompanyIndividualPscList = async (request: Request, companyNumber: string): Promise<CompanyPersonWithSignificantControl[]> => {
-    const IND_PSC_TYPE = "individual-person-with-significant-control";
-    const SUPER_SECURE_PSC_TYPE = "super-secure-person-with-significant-control";
     const response = await getCompanyPscList(request, companyNumber);
     const companyPscs = response.resource as CompanyPersonsWithSignificantControl;
 
@@ -22,7 +21,7 @@ export const getCompanyIndividualPscList = async (request: Request, companyNumbe
     const companyPscList = companyPscs.items;
 
     return companyPscList.filter((psc) => {
-        return (psc.kind === IND_PSC_TYPE || psc.kind === SUPER_SECURE_PSC_TYPE) && (psc.ceasedOn === null || psc.ceasedOn === undefined);
+        return (psc.kind === PSC_KIND_TYPE.INDIVIDUAL || psc.kind === PSC_KIND_TYPE.SUPER_SECURE) && (psc.ceasedOn === null || psc.ceasedOn === undefined);
     });
 };
 

--- a/src/services/companyPscService.ts
+++ b/src/services/companyPscService.ts
@@ -9,6 +9,7 @@ import { HttpStatusCode } from "axios";
 
 export const getCompanyIndividualPscList = async (request: Request, companyNumber: string): Promise<CompanyPersonWithSignificantControl[]> => {
     const IND_PSC_TYPE = "individual-person-with-significant-control";
+    const SUPER_SECURE_PSC_TYPE = "super-secure-person-with-significant-control";
     const response = await getCompanyPscList(request, companyNumber);
     const companyPscs = response.resource as CompanyPersonsWithSignificantControl;
 
@@ -21,7 +22,7 @@ export const getCompanyIndividualPscList = async (request: Request, companyNumbe
     const companyPscList = companyPscs.items;
 
     return companyPscList.filter((psc) => {
-        return psc.kind === IND_PSC_TYPE && (psc.ceasedOn === null || psc.ceasedOn === undefined);
+        return (psc.kind === IND_PSC_TYPE || psc.kind === SUPER_SECURE_PSC_TYPE) && (psc.ceasedOn === null || psc.ceasedOn === undefined);
     });
 };
 

--- a/test/mocks/companyPsc.mock.ts
+++ b/test/mocks/companyPsc.mock.ts
@@ -208,3 +208,24 @@ export const VALID_COMPANY_PSC_LIST: CompanyPersonsWithSignificantControl = {
     },
     items: VALID_COMPANY_PSC_ITEMS
 };
+
+export const SUPER_SECURE_PSCS_EXCLUSIVE_LIST = [
+    {
+        kind: "super-secure-person-with-significant-control",
+        description: "super-secure-persons-with-significant-control",
+        notifiedOn: "2024-03-13",
+        links: {
+            self: "/company/123456/persons-with-significant-control/individual/PSC1"
+        },
+        etag: "ETAG1"
+    },
+    {
+        kind: "super-secure-person-with-significant-control",
+        description: "super-secure-persons-with-significant-control",
+        notifiedOn: "2024-03-13",
+        links: {
+            self: "/company/123456/persons-with-significant-control/individual/PSC2"
+        },
+        etag: "ETAG2"
+    }
+];

--- a/test/mocks/companyPsc.mock.ts
+++ b/test/mocks/companyPsc.mock.ts
@@ -1,4 +1,5 @@
 import { CompanyPersonsWithSignificantControl } from "@companieshouse/api-sdk-node/dist/services/company-psc/types";
+import { PSC_KIND_TYPE } from "../../src/constants";
 
 export const COMPANY_NUMBER = "12345678";
 
@@ -18,7 +19,7 @@ export const INDIVIDUAL_PSCS_LIST = [
         naturesOfControl: [
             "ownership-of-shares-25-to-50-percent-as-trust"
         ],
-        kind: "individual-person-with-significant-control",
+        kind: PSC_KIND_TYPE.INDIVIDUAL,
         nameElements: {
             forename: "Jim",
             surname: "Testerly",
@@ -51,7 +52,7 @@ export const INDIVIDUAL_PSCS_LIST = [
         naturesOfControl: [
             "ownership-of-shares-25-to-50-percent-as-trust"
         ],
-        kind: "individual-person-with-significant-control",
+        kind: PSC_KIND_TYPE.INDIVIDUAL,
         nameElements: {
             forename: "Test",
             otherForenames: "Tester",
@@ -132,7 +133,7 @@ export const VALID_COMPANY_PSC_ITEMS = [
         naturesOfControl: [
             "ownership-of-shares-25-to-50-percent-as-trust"
         ],
-        kind: "individual-person-with-significant-control",
+        kind: PSC_KIND_TYPE.INDIVIDUAL,
         nameElements: {
             forename: "Jim",
             surname: "Testerly",
@@ -165,7 +166,7 @@ export const VALID_COMPANY_PSC_ITEMS = [
         naturesOfControl: [
             "ownership-of-shares-25-to-50-percent-as-trust"
         ],
-        kind: "individual-person-with-significant-control",
+        kind: PSC_KIND_TYPE.INDIVIDUAL,
         nameElements: {
             forename: "Test",
             otherForenames: "Tester",
@@ -211,7 +212,7 @@ export const VALID_COMPANY_PSC_LIST: CompanyPersonsWithSignificantControl = {
 
 export const SUPER_SECURE_PSCS_EXCLUSIVE_LIST = [
     {
-        kind: "super-secure-person-with-significant-control",
+        kind: PSC_KIND_TYPE.SUPER_SECURE,
         description: "super-secure-persons-with-significant-control",
         notifiedOn: "2024-03-13",
         links: {
@@ -220,7 +221,7 @@ export const SUPER_SECURE_PSCS_EXCLUSIVE_LIST = [
         etag: "ETAG1"
     },
     {
-        kind: "super-secure-person-with-significant-control",
+        kind: PSC_KIND_TYPE.SUPER_SECURE,
         description: "super-secure-persons-with-significant-control",
         notifiedOn: "2024-03-13",
         links: {

--- a/test/mocks/psc.mock.ts
+++ b/test/mocks/psc.mock.ts
@@ -1,11 +1,12 @@
 import { PersonWithSignificantControl } from "@companieshouse/api-sdk-node/dist/services/psc/types";
+import { PSC_KIND_TYPE } from "../../src/constants";
 
 export const COMPANY_NUMBER = "12345678";
 export const PSC_ID = "67edfE436y35hetsie6zuAZtr";
 
 export const PSC_INDIVIDUAL: PersonWithSignificantControl = {
     naturesOfControl: ["ownership-of-shares-75-to-100-percent", "voting-rights-75-to-100-percent-as-trust"],
-    kind: "individual-person-with-significant-control",
+    kind: PSC_KIND_TYPE.INDIVIDUAL,
     name: "Sir Forename Middlename Surname",
     nameElements: {
         title: "Sir",

--- a/test/routers/individualPscListRouter.int.ts
+++ b/test/routers/individualPscListRouter.int.ts
@@ -49,7 +49,7 @@ describe("GET psc individual list router", () => {
         expect(pscNameCardTitles).toMatchObject(expectedPscNames);
     });
 
-    it("Should redirect to super-secure stop screen if PSCs are exclusively Super Secure", async () => {
+    it("Should redirect to super secure stop screen if PSCs are exclusively Super Secure", async () => {
         mockGetCompanyIndividualPscList.mockResolvedValue(SUPER_SECURE_PSCS_EXCLUSIVE_LIST);
 
         const resp = await request(app).get(PrefixedUrls.INDIVIDUAL_PSC_LIST + `?companyNumber=${COMPANY_NUMBER}&lang=en`);

--- a/test/routers/individualPscListRouter.int.ts
+++ b/test/routers/individualPscListRouter.int.ts
@@ -1,13 +1,15 @@
 import request from "supertest";
+import * as cheerio from "cheerio";
 import mockSessionMiddleware from "../mocks/sessionMiddleware.mock";
 import mockAuthenticationMiddleware from "../mocks/authenticationMiddleware.mock";
 import app from "../../src/app";
-import { PrefixedUrls } from "../../src/constants";
+import { PrefixedUrls, STOP_TYPE } from "../../src/constants";
 import { getCompanyProfile } from "../../src/services/companyProfileService";
 import { getCompanyIndividualPscList } from "../../src/services/companyPscService";
 import { validCompanyProfile } from "../mocks/companyProfile.mock";
-import { COMPANY_NUMBER, INDIVIDUAL_PSCS_LIST } from "../mocks/companyPsc.mock";
+import { COMPANY_NUMBER, INDIVIDUAL_PSCS_LIST, SUPER_SECURE_PSCS_EXCLUSIVE_LIST } from "../mocks/companyPsc.mock";
 import { HttpStatusCode } from "axios";
+import { getUrlWithStopType } from "../../src/utils/url";
 
 jest.mock("../../src/services/companyProfileService");
 const mockGetCompanyProfile = getCompanyProfile as jest.Mock;
@@ -15,21 +17,44 @@ mockGetCompanyProfile.mockResolvedValue(validCompanyProfile);
 
 jest.mock("../../src/services/companyPscService");
 const mockGetCompanyIndividualPscList = getCompanyIndividualPscList as jest.Mock;
-mockGetCompanyIndividualPscList.mockResolvedValue(INDIVIDUAL_PSCS_LIST);
 
 describe("GET psc individual list router", () => {
     beforeEach(() => {
     });
 
-    afterEach(() => {
+    it("Should return with a successful status code", async () => {
+        mockGetCompanyIndividualPscList.mockResolvedValue(INDIVIDUAL_PSCS_LIST);
+
+        const resp = await request(app).get(PrefixedUrls.INDIVIDUAL_PSC_LIST + `?companyNumber=${COMPANY_NUMBER}&lang=en`);
+
+        expect(resp.status).toBe(HttpStatusCode.Ok);
         expect(mockSessionMiddleware).toHaveBeenCalledTimes(1);
         expect(mockAuthenticationMiddleware).toHaveBeenCalledTimes(1);
         expect(mockGetCompanyProfile).toHaveBeenCalledTimes(1);
         expect(mockGetCompanyIndividualPscList).toHaveBeenCalledTimes(1);
     });
 
-    it("Should return with a successful status code", async () => {
+    it("Should render PSC List screen for ordinary PSCs only, when Super Secure are present", async () => {
+        const ordinaryAndSuperSecurePscs = [...INDIVIDUAL_PSCS_LIST, ...SUPER_SECURE_PSCS_EXCLUSIVE_LIST];
+
+        mockGetCompanyIndividualPscList.mockResolvedValue(ordinaryAndSuperSecurePscs);
+
         const resp = await request(app).get(PrefixedUrls.INDIVIDUAL_PSC_LIST + `?companyNumber=${COMPANY_NUMBER}&lang=en`);
+
         expect(resp.status).toBe(HttpStatusCode.Ok);
+        const $ = cheerio.load(resp.text);
+        const pscNameCardTitles = [...$("div.govuk-summary-card__title-wrapper > h2").contents()].map(e => $(e).text().trim());
+        const templatePlaceholderName = "[Name of the psc]";
+        const expectedPscNames = [...INDIVIDUAL_PSCS_LIST.map(p => p.name), templatePlaceholderName];
+        expect(pscNameCardTitles).toMatchObject(expectedPscNames);
+    });
+
+    it("Should redirect to super-secure stop screen if PSCs are exclusively Super Secure", async () => {
+        mockGetCompanyIndividualPscList.mockResolvedValue(SUPER_SECURE_PSCS_EXCLUSIVE_LIST);
+
+        const resp = await request(app).get(PrefixedUrls.INDIVIDUAL_PSC_LIST + `?companyNumber=${COMPANY_NUMBER}&lang=en`);
+
+        expect(resp.status).toBe(HttpStatusCode.Found);
+        expect(resp.header.location).toBe(`${getUrlWithStopType(PrefixedUrls.STOP_SCREEN, STOP_TYPE.SUPER_SECURE)}?companyNumber=12345678&lang=en`);
     });
 });

--- a/test/services/companyPscService.unit.ts
+++ b/test/services/companyPscService.unit.ts
@@ -3,6 +3,7 @@ import { ApiResponse } from "@companieshouse/api-sdk-node/dist/services/resource
 import { Session } from "@companieshouse/node-session-handler";
 import { HttpStatusCode } from "axios";
 import { Request } from "express";
+import { PSC_KIND_TYPE } from "../../src/constants";
 import { createOAuthApiClient } from "../../src/services/apiClientService";
 import { getCompanyIndividualPscList, getCompanyPscList } from "../../src/services/companyPscService";
 import { COMPANY_NUMBER, EMPTY_COMPANY_PSC_LIST, SUPER_SECURE_PSCS_EXCLUSIVE_LIST, VALID_COMPANY_PSC_ITEMS, VALID_COMPANY_PSC_LIST } from "../mocks/companyPsc.mock";
@@ -94,7 +95,7 @@ describe("companyPscService", () => {
         const individualPscList = await getCompanyIndividualPscList(request, COMPANY_NUMBER);
 
         expect(individualPscList).toHaveLength(3);
-        expect(individualPscList.map(p => p.kind)).toMatchObject(expect.arrayContaining(["individual-person-with-significant-control", "super-secure-person-with-significant-control"]));
+        expect(individualPscList.map(p => p.kind)).toMatchObject(expect.arrayContaining([PSC_KIND_TYPE.INDIVIDUAL, PSC_KIND_TYPE.SUPER_SECURE]));
     });
 
     it("getCompanyIndividualPscList should return an empty list if no individual or super secure PSCs exist for the company", async () => {


### PR DESCRIPTION
- avoid using middleware validation:
  - no second company PSC data fetch in handler
  - and no need to store PSC data in res.locals (potentially much and sensitive)
- check for exclusively super secure in the handler, set an exclusivity flag
- use that flag in router to either route to the appropriate stop screen, or render the PSC list screen