### PR TITLE
Feature/add name mismatch routing validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "license": "MIT",
             "dependencies": {
-                "@companieshouse/api-sdk-node": "^2.0.217",
+                "@companieshouse/api-sdk-node": "github:companieshouse/api-sdk-node#feature/IDVA3-2288-add-get-validation-status",
                 "@companieshouse/ch-node-utils": "^1.3.12",
                 "@companieshouse/node-session-handler": "^5.1.4",
                 "@companieshouse/structured-logging-node": "^2.0.1",
@@ -694,9 +694,8 @@
             }
         },
         "node_modules/@companieshouse/api-sdk-node": {
-            "version": "2.0.217",
-            "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.217.tgz",
-            "integrity": "sha512-gHtFsV2QCKoDFRccfgy4W40vrmIwtnFpoDvV2Z1eBVm/KKD+sg5j7nyaGXlKuwzj3cXKcP/RRO9MZr0wiE8X5w==",
+            "version": "0.0.0",
+            "resolved": "git+ssh://git@github.com/companieshouse/api-sdk-node.git#6350003183a83d1254f6b26c5c44c56088f502ef",
             "license": "MIT",
             "dependencies": {
                 "axios": "^1.7.4",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "coverage": "jest --coverage",
         "test": "jest",
         "test:coverage": "sh ./scripts/jest_coverage.sh",
-        "start": "nodemon",
+        "start": "npm run build && node dist/httpServer.js",
         "start:watch": "nodemon",
         "sonarqube-base-branch": "sonar-scanner",
         "sonarqube-pull-request": "sonar-scanner -D sonar.pullrequest.base=main",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "coverage": "jest --coverage",
         "test": "jest",
         "test:coverage": "sh ./scripts/jest_coverage.sh",
-        "start": "npm run build && node dist/httpServer.js",
+        "start": "nodemon",
         "start:watch": "nodemon",
         "sonarqube-base-branch": "sonar-scanner",
         "sonarqube-pull-request": "sonar-scanner -D sonar.pullrequest.base=main",
@@ -31,7 +31,7 @@
     "author": "Moses Wejuli <mwejuli@companieshouse.gov.uk>",
     "license": "MIT",
     "dependencies": {
-        "@companieshouse/api-sdk-node": "^2.0.217",
+        "@companieshouse/api-sdk-node": "github:companieshouse/api-sdk-node#feature/IDVA3-2288-add-get-validation-status",
         "@companieshouse/ch-node-utils": "^1.3.12",
         "@companieshouse/node-session-handler": "^5.1.4",
         "@companieshouse/structured-logging-node": "^2.0.1",

--- a/src/routers/handlers/personal-code/personalCodeHandler.ts
+++ b/src/routers/handlers/personal-code/personalCodeHandler.ts
@@ -6,10 +6,11 @@ import { addSearchParams } from "../../../utils/queryParams";
 import { getUrlWithTransactionIdAndSubmissionId } from "../../../utils/url";
 import { BaseViewData, GenericHandler, ViewModel } from "../generic";
 import { formatDateBorn } from "../../utils";
-import { PscVerification, PscVerificationData } from "@companieshouse/api-sdk-node/dist/services/psc-verification-link/types";
-import { patchPscVerification } from "../../../services/pscVerificationService";
+import { PscVerification, PscVerificationData, ValidationStatusResponse } from "@companieshouse/api-sdk-node/dist/services/psc-verification-link/types";
+import { getValidationStatus, patchPscVerification } from "../../../services/pscVerificationService";
 import { getPscIndividual } from "../../../services/pscService";
 import { PscVerificationFormsValidator } from "../../../lib/validation/form-validators/pscVerification";
+import { Resource } from "@companieshouse/api-sdk-node";
 
 interface PersonalCodeViewData extends BaseViewData {
     pscName: string,
@@ -76,13 +77,17 @@ export class PersonalCodeHandler extends GenericHandler<PersonalCodeViewData> {
             };
 
             queryParams.set("lang", lang);
-            const nextPageUrl = getUrlWithTransactionIdAndSubmissionId(PrefixedUrls.INDIVIDUAL_STATEMENT, req.params.transactionId, req.params.submissionId);
-            viewData.nextPageUrl = `${nextPageUrl}?${queryParams}`;
+
             const validator = new PscVerificationFormsValidator(lang);
             viewData.errors = await validator.validatePersonalCode(req.body, lang, viewData.pscName);
 
             logger.debug(`${PersonalCodeHandler.name} - ${this.executePost.name} - patching personal code for transaction: ${req.params?.transactionId} and submissionId: ${req.params?.submissionId}`);
             await patchPscVerification(req, req.params.transactionId, req.params.submissionId, verification);
+
+            const validationStatusResponse = await getValidationStatus(req, req.params.transactionId, req.params.submissionId);
+            const url = this.resolveNextPageUrl(validationStatusResponse);
+            const nextPageUrl = getUrlWithTransactionIdAndSubmissionId(url, req.params.transactionId, req.params.submissionId);
+            viewData.nextPageUrl = `${nextPageUrl}?${queryParams}`;
 
         } catch (err: any) {
             logger.error(`${req.method} error: problem handling PSC details (personal code) request: ${err.message}`);
@@ -93,6 +98,17 @@ export class PersonalCodeHandler extends GenericHandler<PersonalCodeViewData> {
             templatePath: PersonalCodeHandler.templatePath,
             viewData
         };
+    }
+
+    private resolveNextPageUrl (validationStatusResponse: Resource<ValidationStatusResponse>): string {
+        let url = PrefixedUrls.INDIVIDUAL_STATEMENT;
+
+        if (validationStatusResponse.resource && validationStatusResponse.resource.isValid === false) {
+            const hasNameMismatchError = validationStatusResponse.resource.errors?.some((validationError: { error: string | string[]; }) => validationError.error.includes("name mismatch"));
+            url = hasNameMismatchError ? PrefixedUrls.NAME_MISMATCH : PrefixedUrls.INDIVIDUAL_STATEMENT;
+        }
+
+        return url;
     }
 
 }

--- a/src/services/pscVerificationService.ts
+++ b/src/services/pscVerificationService.ts
@@ -81,7 +81,7 @@ export const patchPscVerification = async (request: Request, transactionId: stri
     return castedSdkResponse;
 };
 
-export const getValidationStatus = async (request: Request, transactionId: string, pscVerificationId: string): Promise<Resource<ValidationStatusResponse> | ApiErrorResponse> => {
+export const getValidationStatus = async (request: Request, transactionId: string, pscVerificationId: string): Promise<Resource<ValidationStatusResponse>> => {
     const oAuthApiClient: ApiClient = createOAuthApiClient(request.session);
     const logReference = `transaction ${transactionId}, pscVerification ${pscVerificationId}`;
 
@@ -93,7 +93,8 @@ export const getValidationStatus = async (request: Request, transactionId: strin
     }
 
     if (sdkResponse.httpStatusCode !== HttpStatusCode.Ok) {
-        throw createAndLogError(`${getValidationStatus.name} - HTTP status response code is not valid: ${sdkResponse.httpStatusCode} - Failed to GET PSC Verification validation status for ${logReference}`);
+        const errorResponse = sdkResponse as ApiErrorResponse;
+        throw createAndLogError(`${getValidationStatus.name} - Error getting validation status: HTTP response is: ${sdkResponse.httpStatusCode} for ${logReference}: with error response: ${JSON.stringify(errorResponse)}`);
     }
 
     const validationStatus = sdkResponse as Resource<ValidationStatusResponse>;
@@ -101,7 +102,7 @@ export const getValidationStatus = async (request: Request, transactionId: strin
     if (validationStatus.resource?.isValid === false) {
         logger.error(`Validation errors for resource ${logReference}: ` + JSON.stringify(validationStatus.resource.errors.slice(0, 10)));
     } else if (validationStatus.resource?.isValid === undefined) {
-        throw createAndLogError(`${getValidationStatus.name} - Error retrieving the validation status for ${logReference}`);
+        throw createAndLogError(`${getValidationStatus.name} - Error getting validation status for ${logReference}`);
     }
 
     return validationStatus;

--- a/test/mocks/pscVerification.mock.ts
+++ b/test/mocks/pscVerification.mock.ts
@@ -1,5 +1,7 @@
 
+import { Resource } from "@companieshouse/api-sdk-node";
 import { Links, NameMismatchReasonEnum, PscVerification, PscVerificationData, ValidationStatusError, ValidationStatusResponse, VerificationStatementEnum } from "@companieshouse/api-sdk-node/dist/services/psc-verification-link/types";
+import { HttpStatusCode } from "axios";
 
 export const FIRST_DATE = new Date(2024, 0, 2, 3, 4, 5, 6);
 export const DOB_DATE = new Date("1970-01-01");
@@ -155,12 +157,17 @@ function initPscVerification (data: PscVerificationData) {
 }
 
 // validation status mocks
-export const VALIDATION_STATUS_VALID: ValidationStatusResponse = {
+export const VALIDATION_STATUS_RESP_VALID: ValidationStatusResponse = {
     isValid: true,
     errors: []
 };
 
-export const createMockValidationStatusError = (errorMessage: string) : ValidationStatusError => {
+export const VALIDATION_STATUS_RESOURCE_VALID: Resource<ValidationStatusResponse> = {
+    resource: VALIDATION_STATUS_RESP_VALID,
+    httpStatusCode: HttpStatusCode.Ok
+};
+
+const createMockValidationStatusError = (errorMessage: string) : ValidationStatusError => {
     return {
         error: errorMessage,
         location: "$.uvid_match",
@@ -172,10 +179,13 @@ export const createMockValidationStatusError = (errorMessage: string) : Validati
 export const mockValidationStatusNameError: ValidationStatusError = createMockValidationStatusError("The name on the public register is different to the name this PSC used for identity verification: a name mismatch reason must be provided");
 
 export const VALIDATION_STATUS_INVALID: ValidationStatusResponse = {
-    errors: [
-        mockValidationStatusNameError
-    ],
+    errors: [mockValidationStatusNameError],
     isValid: false
+};
+
+export const VALIDATION_STATUS_RESOURCE_INVALID: Resource<ValidationStatusResponse> = {
+    resource: VALIDATION_STATUS_INVALID,
+    httpStatusCode: HttpStatusCode.Ok
 };
 
 // Returns the PSC verification with data fields in camel case

--- a/test/mocks/pscVerification.mock.ts
+++ b/test/mocks/pscVerification.mock.ts
@@ -1,4 +1,5 @@
-import { Links, NameMismatchReasonEnum, PscVerification, PscVerificationData, VerificationStatementEnum } from "@companieshouse/api-sdk-node/dist/services/psc-verification-link/types";
+
+import { Links, NameMismatchReasonEnum, PscVerification, PscVerificationData, ValidationStatusError, ValidationStatusResponse, VerificationStatementEnum } from "@companieshouse/api-sdk-node/dist/services/psc-verification-link/types";
 
 export const FIRST_DATE = new Date(2024, 0, 2, 3, 4, 5, 6);
 export const DOB_DATE = new Date("1970-01-01");
@@ -152,6 +153,30 @@ function initPscVerification (data: PscVerificationData) {
 
     } as PscVerification;
 }
+
+// validation status mocks
+export const VALIDATION_STATUS_VALID: ValidationStatusResponse = {
+    isValid: true,
+    errors: []
+};
+
+export const createMockValidationStatusError = (errorMessage: string) : ValidationStatusError => {
+    return {
+        error: errorMessage,
+        location: "$.uvid_match",
+        type: "ch:validation",
+        locationType: "json-path"
+    };
+};
+
+export const mockValidationStatusNameError: ValidationStatusError = createMockValidationStatusError("The name on the public register is different to the name this PSC used for identity verification: a name mismatch reason must be provided");
+
+export const VALIDATION_STATUS_INVALID: ValidationStatusResponse = {
+    errors: [
+        mockValidationStatusNameError
+    ],
+    isValid: false
+};
 
 // Returns the PSC verification with data fields in camel case
 export const INDIVIDUAL_VERIFICATION_CREATED: PscVerification = initPscVerification(INITIAL_PSC_DATA);

--- a/test/routers/handlers/personal-code/personalCode.unit.ts
+++ b/test/routers/handlers/personal-code/personalCode.unit.ts
@@ -3,14 +3,15 @@ import * as httpMocks from "node-mocks-http";
 import { Urls } from "../../../../src/constants";
 import middlewareMocks from "../../../mocks/allMiddleware.mock";
 import { PSC_INDIVIDUAL } from "../../../mocks/psc.mock";
-import { COMPANY_NUMBER, IND_VERIFICATION_PERSONAL_CODE, PATCH_PERSONAL_CODE_DATA, PSC_APPOINTMENT_ID, PSC_VERIFICATION_ID, TRANSACTION_ID, UVID } from "../../../mocks/pscVerification.mock";
+import { COMPANY_NUMBER, IND_VERIFICATION_PERSONAL_CODE, PATCH_PERSONAL_CODE_DATA, PSC_APPOINTMENT_ID, PSC_VERIFICATION_ID, TRANSACTION_ID, UVID, VALIDATION_STATUS_RESOURCE_INVALID, VALIDATION_STATUS_RESOURCE_VALID } from "../../../mocks/pscVerification.mock";
 import { PersonalCodeHandler } from "../../../../src/routers/handlers/personal-code/personalCodeHandler";
-import { patchPscVerification } from "../../../../src/services/pscVerificationService";
+import { getValidationStatus, patchPscVerification } from "../../../../src/services/pscVerificationService";
 
 jest.mock("../../../../src/services/pscVerificationService", () => ({
     getPscVerification: jest.fn(),
     patchPscVerification: jest.fn(),
-    getPscIndividual: jest.fn()
+    getPscIndividual: jest.fn(),
+    getValidationStatus: jest.fn()
 }));
 
 jest.mock("../../../../src/services/pscService", () => ({
@@ -116,8 +117,10 @@ describe("Personal code handler", () => {
     });
 
     describe("executePost", () => {
+        const mockGetValidationStatus = getValidationStatus as jest.Mock;
 
-        it("should return the correct next page", async () => {
+        it("should return the PSC statement page when the validation status is valid", async () => {
+            mockGetValidationStatus.mockReturnValue(VALIDATION_STATUS_RESOURCE_VALID);
 
             const req = httpMocks.createRequest({
                 method: "POST",
@@ -150,9 +153,48 @@ describe("Personal code handler", () => {
 
             const model = await handler.executePost(req, res);
 
-            expect(model.viewData).toMatchObject({
-                nextPageUrl: `/persons-with-significant-control-verification/transaction/${TRANSACTION_ID}/submission/${PSC_VERIFICATION_ID}/individual/psc-statement?lang=en`
+            expect(patchPscVerification).toHaveBeenCalledTimes(1);
+            expect(model.viewData.nextPageUrl).toBe(`/persons-with-significant-control-verification/transaction/${TRANSACTION_ID}/submission/${PSC_VERIFICATION_ID}/individual/psc-statement?lang=en`);
+
+        });
+
+        it("should return the name mismatch page when there are name validation errors", async () => {
+            mockGetValidationStatus.mockReturnValue(VALIDATION_STATUS_RESOURCE_INVALID);
+
+            const req = httpMocks.createRequest({
+                method: "POST",
+                url: Urls.PERSONAL_CODE,
+                params: {
+                    transactionId: TRANSACTION_ID,
+                    submissionId: PSC_VERIFICATION_ID
+                },
+                query: {
+                    companyNumber: COMPANY_NUMBER,
+                    selectedPscId: PSC_APPOINTMENT_ID,
+                    lang: "en"
+                },
+                body: {
+                    personalCode: UVID
+                }
             });
+
+            const res = httpMocks.createResponse();
+
+            res.locals.submission = {
+                data: {
+                    companyNumber: COMPANY_NUMBER,
+                    pscAppointmentId: PSC_VERIFICATION_ID,
+                    lang: "en"
+                }
+            };
+
+            const handler = new PersonalCodeHandler();
+
+            const model = await handler.executePost(req, res);
+
+            expect(patchPscVerification).toHaveBeenCalledTimes(1);
+            expect(model.viewData.nextPageUrl).toBe(`/persons-with-significant-control-verification/transaction/${TRANSACTION_ID}/submission/${PSC_VERIFICATION_ID}/individual/psc-why-this-name?lang=en`);
+
         });
 
         it("should handle errors and return the correct view data with errors", async () => {
@@ -200,6 +242,7 @@ describe("Personal code handler", () => {
             const result = await handler.executePost(req, res);
 
             expect(patchPscVerification).toHaveBeenCalledTimes(0);
+            expect(getValidationStatus).toHaveBeenCalledTimes(0);
             expect(result.viewData.errors).toBeDefined();
             expect(result.viewData.errors.personalCode).toEqual({
                 summary: "Enter the Companies House personal code for Ralph Tudor",

--- a/test/services/pscVerificationService.unit.ts
+++ b/test/services/pscVerificationService.unit.ts
@@ -1,11 +1,13 @@
-import { PscVerification } from "@companieshouse/api-sdk-node/dist/services/psc-verification-link/types";
+import { PscVerification, ValidationStatusResponse } from "@companieshouse/api-sdk-node/dist/services/psc-verification-link/types";
 import { HttpStatusCode } from "axios";
 import { Request } from "express";
 import { createOAuthApiClient } from "../../src/services/apiClientService";
-import { createPscVerification, getPscVerification, patchPscVerification } from "../../src/services/pscVerificationService";
-import { INDIVIDUAL_VERIFICATION_CREATED, INDIVIDUAL_VERIFICATION_FULL, INDIVIDUAL_VERIFICATION_PATCH, INITIAL_PSC_DATA, PATCH_INDIVIDUAL_DATA, PSC_VERIFICATION_ID, TRANSACTION_ID } from "../mocks/pscVerification.mock";
+import { createPscVerification, getPscVerification, getValidationStatus, patchPscVerification } from "../../src/services/pscVerificationService";
+import { INDIVIDUAL_VERIFICATION_CREATED, INDIVIDUAL_VERIFICATION_FULL, INDIVIDUAL_VERIFICATION_PATCH, INITIAL_PSC_DATA, PATCH_INDIVIDUAL_DATA, PSC_VERIFICATION_ID, TRANSACTION_ID, VALIDATION_STATUS_INVALID, VALIDATION_STATUS_VALID, mockValidationStatusNameError } from "../mocks/pscVerification.mock";
 import { CREATED_PSC_TRANSACTION } from "../mocks/transaction.mock";
 import { Resource } from "@companieshouse/api-sdk-node";
+import { ApiErrorResponse } from "@companieshouse/api-sdk-node/dist/services/resource";
+import { logger } from "../../src/lib/logger";
 
 jest.mock("@companieshouse/api-sdk-node");
 jest.mock("../../src/services/apiClientService");
@@ -13,13 +15,15 @@ jest.mock("../../src/services/apiClientService");
 const mockCreatePscVerification = jest.fn();
 const mockGetPscVerification = jest.fn();
 const mockPatchPscVerification = jest.fn();
+const mockGetValidationStatus = jest.fn();
 const mockCreateOAuthApiClient = createOAuthApiClient as jest.Mock;
 
 mockCreateOAuthApiClient.mockReturnValue({
     pscVerificationService: {
         postPscVerification: mockCreatePscVerification,
         getPscVerification: mockGetPscVerification,
-        patchPscVerification: mockPatchPscVerification
+        patchPscVerification: mockPatchPscVerification,
+        getValidationStatus: mockGetValidationStatus
     }
 });
 
@@ -84,6 +88,133 @@ describe("pscVerificationService", () => {
             expect(mockCreateOAuthApiClient).toHaveBeenCalledTimes(1);
             expect(mockPatchPscVerification).toHaveBeenCalledTimes(1);
             expect(mockPatchPscVerification).toHaveBeenCalledWith(TRANSACTION_ID, PSC_VERIFICATION_ID, PATCH_INDIVIDUAL_DATA);
+        });
+    });
+
+    describe("getValidationStatus", () => {
+        let expected: Resource<ValidationStatusResponse> | ApiErrorResponse;
+
+        it("should return status 200 OK with no errors when the validation status is valid", async () => {
+            expected = {
+                httpStatusCode: HttpStatusCode.Ok,
+                resource: {
+                    isValid: true,
+                    errors: []
+                }
+            } as Resource<ValidationStatusResponse>;
+
+            const mockValidationStatus: Resource<ValidationStatusResponse> = {
+                httpStatusCode: HttpStatusCode.Ok,
+                resource: VALIDATION_STATUS_VALID
+            };
+            mockGetValidationStatus.mockResolvedValueOnce(mockValidationStatus);
+
+            const response = await getValidationStatus(req, TRANSACTION_ID, PSC_VERIFICATION_ID);
+
+            expect(response).toEqual(expected);
+            expect(response.httpStatusCode).toBe(HttpStatusCode.Ok);
+            const castedResource = response as ValidationStatusResponse;
+            expect(castedResource).toEqual(expected);
+            expect(mockCreateOAuthApiClient).toHaveBeenCalledTimes(1);
+            expect(mockGetValidationStatus).toHaveBeenCalledTimes(1);
+            expect(mockGetValidationStatus).toHaveBeenCalledWith(TRANSACTION_ID, PSC_VERIFICATION_ID);
+        });
+
+        it("should return status 200 OK with a validation error when there is a UVID name mismatch", async () => {
+            jest.spyOn(logger, "error").mockImplementation(() => {});
+
+            expected = {
+                httpStatusCode: HttpStatusCode.Ok,
+                resource: {
+                    isValid: false,
+                    errors: [
+                        mockValidationStatusNameError
+                    ]
+                }
+            } as Resource<ValidationStatusResponse>;
+
+            const mockValidationStatus: Resource<ValidationStatusResponse> = {
+                httpStatusCode: HttpStatusCode.Ok,
+                resource: VALIDATION_STATUS_INVALID
+            };
+            mockGetValidationStatus.mockResolvedValueOnce(mockValidationStatus);
+
+            const response = await getValidationStatus(req, TRANSACTION_ID, PSC_VERIFICATION_ID);
+
+            expect(response).toEqual(expected);
+            expect(response.httpStatusCode).toBe(HttpStatusCode.Ok);
+            const castedResource = response as ValidationStatusResponse;
+            expect(castedResource).toEqual(expected);
+            expect(logger.error).toHaveBeenCalled();
+
+            expect(mockCreateOAuthApiClient).toHaveBeenCalledTimes(1);
+            expect(mockGetValidationStatus).toHaveBeenCalledTimes(1);
+            expect(mockGetValidationStatus).toHaveBeenCalledWith(TRANSACTION_ID, PSC_VERIFICATION_ID);
+
+        });
+
+        it("should throw an error when the HTTP status code is not 200 OK", async () => {
+            expected = {
+                httpStatusCode: HttpStatusCode.BadRequest
+            } as ApiErrorResponse;
+
+            mockGetValidationStatus.mockResolvedValueOnce(expected);
+
+            await expect(getValidationStatus(req, TRANSACTION_ID, PSC_VERIFICATION_ID)).rejects.toThrowErrorMatchingInlineSnapshot(
+                `"getValidationStatus - HTTP status response code is not valid: 400 - Failed to GET PSC Verification validation status for transaction 11111-22222-33333, pscVerification 662a0de6a2c6f9aead0f32ab"`
+            );
+
+            expect(mockCreateOAuthApiClient).toHaveBeenCalledTimes(1);
+            expect(mockGetValidationStatus).toHaveBeenCalledTimes(1);
+            expect(mockGetValidationStatus).toHaveBeenCalledWith(TRANSACTION_ID, PSC_VERIFICATION_ID);
+
+        });
+
+        it("should throw an error when the response is null", async () => {
+            mockGetValidationStatus.mockResolvedValueOnce(null);
+
+            await expect(getValidationStatus(req, TRANSACTION_ID, PSC_VERIFICATION_ID)).rejects.toThrowErrorMatchingInlineSnapshot(
+                `"getValidationStatus - PSC Verification GET validation status request did not return a response for transaction 11111-22222-33333, pscVerification 662a0de6a2c6f9aead0f32ab"`
+            );
+
+            expect(mockCreateOAuthApiClient).toHaveBeenCalledTimes(1);
+            expect(mockGetValidationStatus).toHaveBeenCalledTimes(1);
+            expect(mockGetValidationStatus).toHaveBeenCalledWith(TRANSACTION_ID, PSC_VERIFICATION_ID);
+        });
+
+        it("should throw an error when the validationStatus.resource is undefined", async () => {
+            const mockValidationStatus: Resource<ValidationStatusResponse> = {
+                httpStatusCode: HttpStatusCode.Ok,
+                resource: undefined
+            };
+
+            mockGetValidationStatus.mockResolvedValueOnce(mockValidationStatus);
+
+            await expect(getValidationStatus(req, TRANSACTION_ID, PSC_VERIFICATION_ID)).rejects.toThrowErrorMatchingInlineSnapshot(
+                `"getValidationStatus - Error retrieving the validation status for transaction 11111-22222-33333, pscVerification 662a0de6a2c6f9aead0f32ab"`
+            );
+
+            expect(mockCreateOAuthApiClient).toHaveBeenCalledTimes(1);
+            expect(mockGetValidationStatus).toHaveBeenCalledTimes(1);
+            expect(mockGetValidationStatus).toHaveBeenCalledWith(TRANSACTION_ID, PSC_VERIFICATION_ID);
+
+        });
+
+        it("should throw an error when the validationStatus.resource is undefined", async () => {
+            const mockValidationStatus: Resource<ValidationStatusResponse> = {
+                httpStatusCode: HttpStatusCode.Ok
+            };
+
+            mockGetValidationStatus.mockResolvedValueOnce(mockValidationStatus);
+
+            await expect(getValidationStatus(req, TRANSACTION_ID, PSC_VERIFICATION_ID)).rejects.toThrowErrorMatchingInlineSnapshot(
+                `"getValidationStatus - Error retrieving the validation status for transaction 11111-22222-33333, pscVerification 662a0de6a2c6f9aead0f32ab"`
+            );
+
+            expect(mockCreateOAuthApiClient).toHaveBeenCalledTimes(1);
+            expect(mockGetValidationStatus).toHaveBeenCalledTimes(1);
+            expect(mockGetValidationStatus).toHaveBeenCalledWith(TRANSACTION_ID, PSC_VERIFICATION_ID);
+
         });
     });
 });

--- a/test/services/pscVerificationService.unit.ts
+++ b/test/services/pscVerificationService.unit.ts
@@ -199,22 +199,5 @@ describe("pscVerificationService", () => {
             expect(mockGetValidationStatus).toHaveBeenCalledWith(TRANSACTION_ID, PSC_VERIFICATION_ID);
 
         });
-
-        it("should throw an error when the validationStatus.resource is undefined", async () => {
-            const mockValidationStatus: Resource<ValidationStatusResponse> = {
-                httpStatusCode: HttpStatusCode.Ok
-            };
-
-            mockGetValidationStatus.mockResolvedValueOnce(mockValidationStatus);
-
-            await expect(getValidationStatus(req, TRANSACTION_ID, PSC_VERIFICATION_ID)).rejects.toThrowErrorMatchingInlineSnapshot(
-                `"getValidationStatus - Error retrieving the validation status for transaction 11111-22222-33333, pscVerification 662a0de6a2c6f9aead0f32ab"`
-            );
-
-            expect(mockCreateOAuthApiClient).toHaveBeenCalledTimes(1);
-            expect(mockGetValidationStatus).toHaveBeenCalledTimes(1);
-            expect(mockGetValidationStatus).toHaveBeenCalledWith(TRANSACTION_ID, PSC_VERIFICATION_ID);
-
-        });
     });
 });


### PR DESCRIPTION
### Validate and Route to the name mismatch screen when there is a name mismatch

1. Update `pscVerificationService` to retrieve the validation status from the API
2. Add unit tests and mocks for `getValidationStatus`
3. Update `PersonalCodeHandler` to call the validation status and route to the individual statement page when valid
5. Update `PersonalCodeHandler` when there is a name mismatch validation error to route to the name mismatch page
6. Update Personal Code tests
7. Temporarily add `api-sdk-node` branch reference for `api-sdk-node` PR in the  [Add functionality to GET the validation status](https://github.com/companieshouse/api-sdk-node/pull/738). To be reverted to the `api-sdk-node` master branch once approved.