### PR TITLE
IDVA3-2629 Insert message on psc-list screen for no individual PSC scenario

### DIFF
--- a/locales/cy/stop-screens.json
+++ b/locales/cy/stop-screens.json
@@ -30,6 +30,8 @@
   "dob_mismatch_up_to_date": "to be translated",
   "dob_mismatch_authorised_agent": "to be translated",
   "dob_mismatch_verified_identity": "to be translated",
+  "empty_psc_list_body": "to be translated",
+  "empty_psc_list_link": "to be translated",
   "rp01_guidance_main_title": "to be translated",
   "rp01_guidance_intro": "to be translated",
   "rp01_guidance_step_1": "to be translated",

--- a/locales/en/stop-screens.json
+++ b/locales/en/stop-screens.json
@@ -30,6 +30,8 @@
   "dob_mismatch_up_to_date": "When the details are up to date on the register, you will be able to return to this service and provide your Companies House personal code.",
   "dob_mismatch_authorised_agent": "If you verified using an authorised agent, check they entered the correct date of birth",
   "dob_mismatch_verified_identity": "If you verified your identity through an authorised agent (such as an accountant), confirm that they typed your details in correctly when they verified your identity.",
+  "empty_psc_list_body": "This company does not have any PSCs. For information on how to identify and record a company's PSCs, ",
+  "empty_psc_list_link": "read the guidance on people with significant control (PSCs)",
   "rp01_guidance_main_title": "Correcting the PSC date of birth on the Companies House register",
   "rp01_guidance_intro": "To correct the date of birth on the Companies House register, someone authorised to file for this company will need to submit a paper corrections form. They should follow this process.",
   "rp01_guidance_step_1": "Print and fill in the RP01 form:",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,6 +4,7 @@ const urlWithTransactionIdAndSubmissionId = "/transaction/:transactionId/submiss
 export enum STOP_TYPE {
     COMPANY_STATUS = "company-status",
     COMPANY_TYPE = "company-type",
+    EMPTY_PSC_LIST = "empty-psc-list",
     PSC_DOB_MISMATCH = "psc-dob-mismatch",
     RP01_GUIDANCE = "rp01-guidance",
     SUPER_SECURE = "super-secure"

--- a/src/routers/handlers/individual-psc-list/individualPscListHandler.ts
+++ b/src/routers/handlers/individual-psc-list/individualPscListHandler.ts
@@ -11,6 +11,7 @@ import { logger } from "../../../lib/logger";
 
 interface PscListData {
     pscId: string,
+    pscCeasedOn?: string,
     pscKind?: string,
     pscName?: string,
     pscDob?: string,
@@ -25,6 +26,7 @@ interface IndividualPscListViewData extends BaseViewData {
     pscDetails: PscListData[],
     exclusivelySuperSecure: boolean,
     selectedPscId: string | null,
+    showNoPscsMessage: boolean,
     nextPageUrl: string | null
 }
 
@@ -57,6 +59,11 @@ export class IndividualPscListHandler extends GenericHandler<IndividualPscListVi
         }
 
         const allPscDetails = this.getViewPscDetails(individualPscList, lang);
+        const allSuperSecure = allPscDetails.every((psc) => psc.pscKind === PSC_KIND_TYPE.SUPER_SECURE);
+        const allCeased = allPscDetails.every((psc) => psc.pscCeasedOn != null);
+
+        const exclusivelySuperSecure = allPscDetails.length > 0 && (allSuperSecure && !allCeased);
+        const showNoPscsMessage = allPscDetails.length === 0 || allCeased;
 
         return {
             ...baseViewData,
@@ -69,7 +76,8 @@ export class IndividualPscListHandler extends GenericHandler<IndividualPscListVi
             dsrEmailAddress,
             dsrPhoneNumber,
             pscDetails: allPscDetails.filter(psc => psc.pscKind === PSC_KIND_TYPE.INDIVIDUAL),
-            exclusivelySuperSecure: allPscDetails.every((psc) => psc.pscKind === PSC_KIND_TYPE.SUPER_SECURE),
+            exclusivelySuperSecure,
+            showNoPscsMessage,
             templateName: Urls.INDIVIDUAL_PSC_LIST
         };
 
@@ -94,6 +102,7 @@ export class IndividualPscListHandler extends GenericHandler<IndividualPscListVi
 
             return {
                 pscId: psc.links.self.split("/").pop() as string,
+                pscCeasedOn: psc.ceasedOn,
                 pscKind: psc.kind,
                 pscName: psc.name,
                 pscDob: pscFormattedDob,

--- a/src/routers/handlers/stop-screen/stopScreenHandler.ts
+++ b/src/routers/handlers/stop-screen/stopScreenHandler.ts
@@ -60,6 +60,15 @@ const setContent = async (req: Request, res: Response, stopType: STOP_TYPE, base
                 backURL: addSearchParams(resolveUrlTemplate(PrefixedUrls.CONFIRM_COMPANY), { companyNumber }),
                 extraData: [companyName, resolveUrlTemplate(PrefixedUrls.COMPANY_NUMBER), env.CONTACT_US_LINK]
             };
+        case STOP_TYPE.EMPTY_PSC_LIST: {
+            return {
+                ...baseViewData,
+                ...getLocaleInfo(locales, lang),
+                templateName: stopType,
+                currentUrl: addSearchParams(getUrlWithStopType(stopScreenPrefixedUrl, stopType), { companyNumber, lang }),
+                backURL: addSearchParams(PrefixedUrls.CONFIRM_COMPANY, { companyNumber, lang })
+            };
+        }
         case STOP_TYPE.PSC_DOB_MISMATCH: {
             return {
                 ...baseViewData,

--- a/src/routers/individualPscListRouter.ts
+++ b/src/routers/individualPscListRouter.ts
@@ -19,6 +19,9 @@ individualPscListRouter.get("/", handleExceptions(async (req: Request, res: Resp
     if (viewData.exclusivelySuperSecure) {
         logger.debug(`individualPscListRouter.get - PSCs are exclusively Super Secure for company number ${companyNumber}: paper filing is required`);
         res.redirect(addSearchParams(getUrlWithStopType(PrefixedUrls.STOP_SCREEN, STOP_TYPE.SUPER_SECURE), { companyNumber, lang }));
+    } else if (viewData.showNoPscsMessage) {
+        logger.debug(`individualPscListRouter.get - there are no PSCs for company number ${companyNumber}`);
+        res.redirect(addSearchParams(getUrlWithStopType(PrefixedUrls.STOP_SCREEN, STOP_TYPE.EMPTY_PSC_LIST), { companyNumber, lang }));
     } else {
         res.render(templatePath, viewData);
     }

--- a/src/views/router_views/stopScreen/empty-psc-list.njk
+++ b/src/views/router_views/stopScreen/empty-psc-list.njk
@@ -1,0 +1,15 @@
+{% set title = i18n.ind_psc_list_main_title %}
+
+{% extends "layouts/default.njk" %}
+
+{% block main_content %}
+
+<h1 class="govuk-heading-l">{{ i18n.ind_psc_list_main_title }}</h1>
+<p class="govuk-body">
+  {{ i18n.empty_psc_list_body }}
+  <a href="https://www.gov.uk/guidance/people-with-significant-control-pscs">
+    {{ i18n.empty_psc_list_link }}
+  </a>.
+</p>
+
+{% endblock %}

--- a/test/mocks/companyPsc.mock.ts
+++ b/test/mocks/companyPsc.mock.ts
@@ -84,6 +84,44 @@ export const INDIVIDUAL_PSCS_LIST = [
     }
 ];
 
+export const CEASED_PSCS_EXCLUSIVE_LIST = [
+    {
+        naturesOfControl: [
+            "ownership-of-shares-25-to-50-percent-as-trust"
+        ],
+        kind: PSC_KIND_TYPE.INDIVIDUAL,
+        nameElements: {
+            forename: "Test",
+            otherForenames: "Tester",
+            surname: "Testington",
+            title: "Mr"
+        },
+        name: "Mr Test Tester Testington",
+        notifiedOn: "2024-03-13",
+        nationality: "British",
+        address: {
+            postalCode: "CF14 3UZ",
+            premises: "1",
+            locality: "Cardiff",
+            addressLine1: "34 Silver Street",
+            addressLine2: "Silverstone",
+            careOf: "Care of",
+            poBox: "Po Box",
+            region: "UK"
+        },
+        ceasedOn: "2024-03-13",
+        countryOfResidence: "Wales",
+        dateOfBirth: {
+            year: "1997",
+            month: "12"
+        },
+        links: {
+            self: "/company/123456/persons-with-significant-control/individual/PSC2"
+        },
+        etag: "ETAG2"
+    }
+];
+
 export const VALID_COMPANY_PSC_ITEMS = [
     {
         naturesOfControl: [

--- a/test/routers/handlers/stop-screen/stopScreen.int.ts
+++ b/test/routers/handlers/stop-screen/stopScreen.int.ts
@@ -75,6 +75,10 @@ describe("stop screen view tests", () => {
                 expect($("a#go-back-enter-number").attr("href")).toBe(`${PrefixedUrls.COMPANY_NUMBER}?lang=en`);
                 expect($("a#contact-us").attr("href")).toBe(env.CONTACT_US_LINK);
                 break;
+            case STOP_TYPE.EMPTY_PSC_LIST:
+                expect($("a.govuk-back-link").attr("href")).toBe(`${PrefixedUrls.CONFIRM_COMPANY}?companyNumber=00006400&lang=en`);
+                expect($("p.govuk-body").text()).toContain("This company does not have any PSCs.");
+                break;
             case STOP_TYPE.PSC_DOB_MISMATCH:
                 expect($("a.govuk-back-link").attr("href")).toBe(`${expectedPrefix}/individual/personal-code?lang=en`);
                 expect($("a#reenter-personal-code").attr("href")).toBe(`${expectedPrefix}/individual/personal-code?lang=en`);

--- a/test/routers/handlers/stop-screen/stopScreenHandler.unit.ts
+++ b/test/routers/handlers/stop-screen/stopScreenHandler.unit.ts
@@ -84,6 +84,13 @@ describe("Stop screen handler", () => {
                             extraData: [validCompanyProfile.companyName, `${PrefixedUrls.COMPANY_NUMBER}?lang=en`, env.CONTACT_US_LINK]
                         });
                     break;
+                case STOP_TYPE.EMPTY_PSC_LIST:
+                    expect(viewData).toMatchObject({
+                        ...expectedViewData,
+                        currentUrl: `/persons-with-significant-control-verification/stop/${stopType}?companyNumber=00006400&lang=en`,
+                        backURL: `${PrefixedUrls.CONFIRM_COMPANY}?companyNumber=00006400&lang=en`
+                    });
+                    break;
                 case STOP_TYPE.PSC_DOB_MISMATCH:
                     expect(viewData).toMatchObject(
                         {

--- a/test/routers/individualPscListRouter.int.ts
+++ b/test/routers/individualPscListRouter.int.ts
@@ -7,7 +7,7 @@ import { PrefixedUrls, STOP_TYPE } from "../../src/constants";
 import { getCompanyProfile } from "../../src/services/companyProfileService";
 import { getCompanyIndividualPscList } from "../../src/services/companyPscService";
 import { validCompanyProfile } from "../mocks/companyProfile.mock";
-import { COMPANY_NUMBER, INDIVIDUAL_PSCS_LIST, SUPER_SECURE_PSCS_EXCLUSIVE_LIST } from "../mocks/companyPsc.mock";
+import { CEASED_PSCS_EXCLUSIVE_LIST, COMPANY_NUMBER, INDIVIDUAL_PSCS_LIST, SUPER_SECURE_PSCS_EXCLUSIVE_LIST } from "../mocks/companyPsc.mock";
 import { HttpStatusCode } from "axios";
 import { getUrlWithStopType } from "../../src/utils/url";
 
@@ -47,6 +47,22 @@ describe("GET psc individual list router", () => {
         const templatePlaceholderName = "[Name of the psc]";
         const expectedPscNames = [...INDIVIDUAL_PSCS_LIST.map(p => p.name), templatePlaceholderName];
         expect(pscNameCardTitles).toMatchObject(expectedPscNames);
+    });
+
+    it("Should render the empty PSC list stop screen when there are no PSCs", async () => {
+        mockGetCompanyIndividualPscList.mockResolvedValue([]);
+        const resp = await request(app).get(PrefixedUrls.INDIVIDUAL_PSC_LIST + `?companyNumber=${COMPANY_NUMBER}&lang=en`);
+
+        expect(resp.status).toBe(HttpStatusCode.Found);
+        expect(resp.header.location).toBe(`${getUrlWithStopType(PrefixedUrls.STOP_SCREEN, STOP_TYPE.EMPTY_PSC_LIST)}?companyNumber=12345678&lang=en`);
+    });
+
+    it("Should render the empty PSC list stop screen when all PSCs are ceased", async () => {
+        mockGetCompanyIndividualPscList.mockResolvedValue(CEASED_PSCS_EXCLUSIVE_LIST);
+        const resp = await request(app).get(PrefixedUrls.INDIVIDUAL_PSC_LIST + `?companyNumber=${COMPANY_NUMBER}&lang=en`);
+
+        expect(resp.status).toBe(HttpStatusCode.Found);
+        expect(resp.header.location).toBe(`${getUrlWithStopType(PrefixedUrls.STOP_SCREEN, STOP_TYPE.EMPTY_PSC_LIST)}?companyNumber=12345678&lang=en`);
     });
 
     it("Should redirect to super secure stop screen if PSCs are exclusively Super Secure", async () => {


### PR DESCRIPTION
# [IDVA3-2629](https://companieshouse.atlassian.net/browse/IDVA3-2629) Insert message on psc-list screen for no individual PSC scenario 

## Notes
I wanted to use `it.each` for the Jest tests since they're largely the same, but I ran into an issue where `it.each` is causing a timeout every time. I've asked Simon for help.

[IDVA3-2629]: https://companieshouse.atlassian.net/browse/IDVA3-2629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ