### PR TITLE
 IDVA3-2572 Matomo tracking for cloudy day screens

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -85,5 +85,7 @@ export const SessionKeys = {
 
 // Matomo event IDs that occur more than once accross templates
 export const CommonDataEventIds = {
-    CONTINUE_BUTTON: "continue-button"
+    CONTACT_US_LINK: "contact-us-link",
+    CONTINUE_BUTTON: "continue-button",
+    GO_BACK_AND_RETRY_LINK: "go-back-and-retry-link"
 } as const;

--- a/src/views/router_views/error/internal-server-error.njk
+++ b/src/views/router_views/error/internal-server-error.njk
@@ -7,6 +7,6 @@
     <p class="govuk-body">{{ i18n.500_try_again_later }}</p>
     <p class="govuk-body">{{ i18n.500_when_available_start_again }}</p>
     <p class="govuk-body">
-      <a href="{{ extraData[0] }}">{{ i18n.500_contact_us_1 }}</a> {{ i18n.500_contact_us_2 }}
+      <a href="{{ extraData[0] }}" data-event-id="{{ CommonDataEventIds.CONTACT_US_LINK }}">{{ i18n.500_contact_us_1 }}</a> {{ i18n.500_contact_us_2 }}
     </p>
 {% endblock %}

--- a/src/views/router_views/error/page-not-found.njk
+++ b/src/views/router_views/error/page-not-found.njk
@@ -8,6 +8,6 @@
     <p class="govuk-body">{{ i18n.404_check_typed_address }}</p>
     <p class="govuk-body">{{ i18n.404_check_pasted_address }}</p>
     <p class="govuk-body">
-        <a href="{{ extraData[0] }}">{{ i18n.404_arrived_via_bad_url_1 }}</a> {{ i18n.404_arrived_via_bad_url_2 }}
+        <a href="{{ extraData[0] }}" data-event-id="{{ CommonDataEventIds.CONTACT_US_LINK }}">{{ i18n.404_arrived_via_bad_url_1 }}</a> {{ i18n.404_arrived_via_bad_url_2 }}
     </p>
 {% endblock %}

--- a/src/views/router_views/name_mismatch/name_mismatch.njk
+++ b/src/views/router_views/name_mismatch/name_mismatch.njk
@@ -27,7 +27,9 @@
 
         <p class="govuk-body">
             {{ i18n.name_mismatch_details_par2 }}
-            <a href="https://www.gov.uk/file-changes-to-a-company-with-companies-house" class="govuk-link" rel="noreferrer noopener" target="_blank">{{ i18n.name_mismatch_details_par2_link }}</a>
+            <a href="https://www.gov.uk/file-changes-to-a-company-with-companies-house" class="govuk-link" rel="noreferrer noopener" target="_blank" data-event-id="update-name-on-register-link">
+              {{ i18n.name_mismatch_details_par2_link }}
+            </a>
             {{- i18n.name_mismatch_details_par2_after_link }}
         </p>
 

--- a/src/views/router_views/serviceUnavailable/service-unavailable.njk
+++ b/src/views/router_views/serviceUnavailable/service-unavailable.njk
@@ -8,6 +8,6 @@
     <p class="govuk-body">{{ i18n.service_unavailable_use }}{{ extraData[0] }}.</p>
     <p class="govuk-body">{{ i18n.service_unavailable_when_available_start_again }}</p>
     <p class="govuk-body">
-      <a href="{{ extraData[1] }}">{{ i18n.service_unavailable_contact_us_1 }}</a> {{ i18n.service_unavailable_contact_us_2 }}
+      <a href="{{ extraData[1] }}" data-event-id="{{ CommonDataEventIds.CONTACT_US_LINK }}">{{ i18n.service_unavailable_contact_us_1 }}</a> {{ i18n.service_unavailable_contact_us_2 }}
     </p>
 {% endblock %}

--- a/src/views/router_views/stopScreen/company-status.njk
+++ b/src/views/router_views/stopScreen/company-status.njk
@@ -9,10 +9,10 @@
     <p class="govuk-body">{{ extraData[0] }}{{ i18n.company_status_statement_1 }}</p>
     <p class="govuk-body">{{ i18n.company_status_statement_2 }}</p>
     <p class="govuk-body">{{ i18n.company_status_wrong_company_action }}
-        <a id="go-back-enter-number" href="{{ extraData[1] }}">{{ i18n.company_status_wrong_company_action_text -}}</a>.
+        <a id="go-back-enter-number" href="{{ extraData[1] }}" data-event-id="{{ CommonDataEventIds.GO_BACK_AND_RETRY_LINK }}">{{ i18n.company_status_wrong_company_action_text -}}</a>.
     </p>
     <p class="govuk-body">
-        <a id="contact-us" href="{{ extraData[2] }}">{{ i18n.company_status_contact_us_text -}}</a>
+        <a id="contact-us" href="{{ extraData[2] }}" data-event-id="{{ CommonDataEventIds.CONTACT_US_LINK }}">{{ i18n.company_status_contact_us_text -}}</a>
         {{ i18n.company_status_contact_us }}
     </p>
 

--- a/src/views/router_views/stopScreen/company-type.njk
+++ b/src/views/router_views/stopScreen/company-type.njk
@@ -14,10 +14,10 @@
         <li>{{ i18n.company_type_allowed_4 }}</li>
     </ul>
     <p class="govuk-body">{{ i18n.company_type_wrong_company_action }}
-        <a id="go-back-enter-number" href="{{ extraData[1] }}">{{ i18n.company_type_wrong_company_action_text -}}</a>.
+        <a id="go-back-enter-number" href="{{ extraData[1] }}" data-event-id="{{ CommonDataEventIds.GO_BACK_AND_RETRY_LINK }}">{{ i18n.company_type_wrong_company_action_text -}}</a>.
     </p>
     <p class="govuk-body">
-        <a id="contact-us" href="{{ extraData[2] }}">{{ i18n.company_type_contact_us_text -}}</a>
+        <a id="contact-us" href="{{ extraData[2] }}" data-event-id="{{ CommonDataEventIds.CONTACT_US_LINK }}">{{ i18n.company_type_contact_us_text -}}</a>
         {{ i18n.company_type_contact_us }}
     </p>
 

--- a/src/views/router_views/stopScreen/empty-psc-list.njk
+++ b/src/views/router_views/stopScreen/empty-psc-list.njk
@@ -7,7 +7,7 @@
 <h1 class="govuk-heading-l">{{ i18n.ind_psc_list_main_title }}</h1>
 <p class="govuk-body">
   {{ i18n.empty_psc_list_body }}
-  <a href="https://www.gov.uk/guidance/people-with-significant-control-pscs">
+  <a href="https://www.gov.uk/guidance/people-with-significant-control-pscs" data-event-id="guidance-link">
     {{ i18n.empty_psc_list_link }}
   </a>.
 </p>

--- a/src/views/router_views/stopScreen/psc-dob-mismatch.njk
+++ b/src/views/router_views/stopScreen/psc-dob-mismatch.njk
@@ -10,7 +10,7 @@
     <h3 class="govuk-heading-s">{{ i18n.dob_mismatch_check_personal_code }}</h3>
     <p class="govuk-body">
         {{ i18n.dob_mismatch_character_code }}
-        <a id="reenter-personal-code" href="{{ backURL }}" title="{{ i18n.dob_mismatch_try_again_link }}" class="govuk-link" data-event-id="try-again-link">
+        <a id="reenter-personal-code" href="{{ backURL }}" title="{{ i18n.dob_mismatch_try_again_link }}" class="govuk-link" data-event-id="{{ CommonDataEventIds.GO_BACK_AND_RETRY_LINK }}">
             {{ i18n.dob_mismatch_try_again_link_text -}}
         </a>.
     </p>

--- a/src/views/router_views/stopScreen/super-secure.njk
+++ b/src/views/router_views/stopScreen/super-secure.njk
@@ -8,7 +8,7 @@
     <p class="govuk-body">{{ i18n.super_secure_statement_1 }}</p>
     <p class="govuk-body">{{ i18n.super_secure_statement_2 }}</p>
     <p class="govuk-body">{{ i18n.super_secure_statement_3_1 }}
-        <a id="mail-to-dsr" href="mailto:{{ extraData[0] }}" target="_blank" >{{ extraData[0] }}</a>
+        <a id="mail-to-dsr" href="mailto:{{ extraData[0] }}" target="_blank" data-event-id="dsr-mailto-link">{{ extraData[0] }}</a>
         {{ i18n.super_secure_statement_3_2 }}
         {{ extraData[1] }}{{ i18n.super_secure_statement_3_3 }}
     </p>


### PR DESCRIPTION
# [IDVA3-2572](https://companieshouse.atlassian.net/browse/IDVA3-2572) Matomo tracking for cloudy day screens

Testing involves going to each route, clicking the updated links, and checking their events fire correctly on the [Matomo dashboard](https://matomo.platform.aws.chdev.org/index.php?module=CoreHome&action=index&idSite=24&period=day&date=today&updated=1#?idSite=24&period=day&date=today&category=Dashboard_Dashboard&subcategory=1&segment=pageUrl%3D@persons-with-significant-control) (you may need to adjust the date range).


[IDVA3-2572]: https://companieshouse.atlassian.net/browse/IDVA3-2572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ