### PR TITLE
IDVA3-2783 Update wording in psc-statement screen

### DIFF
--- a/locales/en/individual-statement.json
+++ b/locales/en/individual-statement.json
@@ -2,7 +2,7 @@
     "individual_statement_title": "Confirm the identity verification statement",
     "individual_statement_value": "individual_statement",
     "individual_statement_part1": "I confirm that ",
-    "individual_statement_part2": " has verified their identity for Companies House.",
+    "individual_statement_part2": " has verified their identity in accordance with the Companies Act 2006.",
     "individual_statement_born": "Born ",
     "individual_statement_button": "Confirm and submit",
     "individual_statement_error_summary": "Select the identity verification statement",

--- a/test/routers/handlers/individual-statement/individualStatement.int.ts
+++ b/test/routers/handlers/individual-statement/individualStatement.int.ts
@@ -60,7 +60,7 @@ describe("individual statement router/handler integration tests", () => {
             if (lang === "en") {
                 expect($("div#nameAndDateOfBirth").text()).toBe("Sir Forename Middlename Surname (Born April 2000)");
                 // expect emphasis applied to PSC name
-                expect(normalizeWhitespace($("label.govuk-checkboxes__label[for='pscIndividualStatement']").html())).toBe("<label for=\"pscIndividualStatement\">I confirm that <strong>Sir Forename Middlename Surname</strong> has verified their identity for Companies House.</label>");
+                expect(normalizeWhitespace($("label.govuk-checkboxes__label[for='pscIndividualStatement']").html())).toBe("<label for=\"pscIndividualStatement\">I confirm that <strong>Sir Forename Middlename Surname</strong> has verified their identity in accordance with the Companies Act 2006.</label>");
             }
 
             expect($("input.govuk-checkboxes__input[name=pscIndividualStatement]").prop("checked")).toBe(true);
@@ -85,7 +85,7 @@ describe("individual statement router/handler integration tests", () => {
             if (lang === "en") {
                 expect($("div#nameAndDateOfBirth").text()).toBe("Sir Forename Middlename Surname (Born April 2000)");
                 // expect emphasis applied to PSC name
-                expect(normalizeWhitespace($("label.govuk-checkboxes__label[for='pscIndividualStatement']").html())).toBe("<label for=\"pscIndividualStatement\">I confirm that <strong>Sir Forename Middlename Surname</strong> has verified their identity for Companies House.</label>");
+                expect(normalizeWhitespace($("label.govuk-checkboxes__label[for='pscIndividualStatement']").html())).toBe("<label for=\"pscIndividualStatement\">I confirm that <strong>Sir Forename Middlename Surname</strong> has verified their identity in accordance with the Companies Act 2006.</label>");
             }
 
             expect($("input.govuk-checkboxes__input[name=pscIndividualStatement]").prop("checked")).toBe(true);


### PR DESCRIPTION
# [IDVA3-2783](https://companieshouse.atlassian.net/browse/IDVA3-2783) Update wording in psc-statement screen

Only a small change to localised strings & altered tests.

[IDVA3-2783]: https://companieshouse.atlassian.net/browse/IDVA3-2783?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ