### PR TITLE
Add check before creating new Verification

### DIFF
--- a/src/services/pscVerificationService.ts
+++ b/src/services/pscVerificationService.ts
@@ -9,6 +9,10 @@ import { createAndLogError, logger } from "../lib/logger";
 import { createApiKeyClient, createOAuthApiClient } from "./apiClientService";
 
 export const createPscVerification = async (request: Request, transaction: Transaction, pscVerification: PscVerificationData): Promise<Resource<PscVerification>> => {
+    if (pscVerification.pscNotificationId == null) {
+        throw createAndLogError(`${createPscVerification.name} - Aborting: pscNotificationId is required for PSC Verification POST request for transaction ${transaction.id}`);
+    }
+
     const oAuthApiClient: ApiClient = createOAuthApiClient(request.session);
 
     logger.debug(`Creating PSC verification resource for ${transaction.description} transaction ${transaction.id}`);

--- a/src/services/pscVerificationService.ts
+++ b/src/services/pscVerificationService.ts
@@ -10,7 +10,7 @@ import { createApiKeyClient, createOAuthApiClient } from "./apiClientService";
 
 export const createPscVerification = async (request: Request, transaction: Transaction, pscVerification: PscVerificationData): Promise<Resource<PscVerification>> => {
     if (pscVerification.pscNotificationId == null) {
-        throw createAndLogError(`${createPscVerification.name} - Aborting: pscNotificationId is required for PSC Verification POST request for transaction ${transaction.id}`);
+        throw createAndLogError(`${createPscVerification.name} - Aborting: pscNotificationId is required for PSC Verification POST request for transaction ${transaction.id}. Has the user tried to resume a journey after signing out and in again?`);
     }
 
     const oAuthApiClient: ApiClient = createOAuthApiClient(request.session);

--- a/test/services/pscVerificationService.unit.ts
+++ b/test/services/pscVerificationService.unit.ts
@@ -92,7 +92,7 @@ describe("pscVerificationService", () => {
             };
 
             await expect(createPscVerification(req, CREATED_PSC_TRANSACTION, incompleteData)).rejects.toThrow(
-                new Error(`createPscVerification - Aborting: pscNotificationId is required for PSC Verification POST request for transaction ${TRANSACTION_ID}`));
+                new Error(`createPscVerification - Aborting: pscNotificationId is required for PSC Verification POST request for transaction ${TRANSACTION_ID}. Has the user tried to resume a journey after signing out and in again?`));
         });
     });
 

--- a/test/services/pscVerificationService.unit.ts
+++ b/test/services/pscVerificationService.unit.ts
@@ -1,5 +1,5 @@
 import { Resource } from "@companieshouse/api-sdk-node";
-import { PlannedMaintenance, PscVerification, ValidationStatusResponse } from "@companieshouse/api-sdk-node/dist/services/psc-verification-link/types";
+import { PlannedMaintenance, PscVerification, PscVerificationData, ValidationStatusResponse } from "@companieshouse/api-sdk-node/dist/services/psc-verification-link/types";
 import { ApiErrorResponse, ApiResponse } from "@companieshouse/api-sdk-node/dist/services/resource";
 import { HttpStatusCode } from "axios";
 import { Request } from "express";
@@ -85,6 +85,14 @@ describe("pscVerificationService", () => {
 
             await expect(createPscVerification(req, CREATED_PSC_TRANSACTION, INITIAL_PSC_DATA)).rejects.toThrow(
                 new Error(`createPscVerification - HTTP status code 503 - Failed to POST PSC Verification for transaction ${TRANSACTION_ID}`));
+        });
+        it("should throw an Error when pscNotificationId is undefined", async () => {
+            const incompleteData: PscVerificationData = {
+                companyNumber: INITIAL_PSC_DATA.companyNumber
+            };
+
+            await expect(createPscVerification(req, CREATED_PSC_TRANSACTION, incompleteData)).rejects.toThrow(
+                new Error(`createPscVerification - Aborting: pscNotificationId is required for PSC Verification POST request for transaction ${TRANSACTION_ID}`));
         });
     });
 
@@ -241,7 +249,7 @@ describe("pscVerificationService", () => {
         });
 
         it("should return status 200 OK with a validation error when there is a UVID name mismatch", async () => {
-            jest.spyOn(logger, "error").mockImplementation(() => {});
+            jest.spyOn(logger, "error").mockImplementation(() => { });
 
             expected = {
                 httpStatusCode: HttpStatusCode.Ok,


### PR DESCRIPTION
Check that pscNotificationId is not missing before making POST request to API. If so then record in service log and throw an Error as expected.