### PR TITLE
IDVA3-2470 Add get psc verification state endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "license": "MIT",
             "dependencies": {
-                "@companieshouse/api-sdk-node": "^2.0.243",
+                "@companieshouse/api-sdk-node": "github:companieshouse/api-sdk-node#feature/add-psc-verification-state-endpoint",
                 "@companieshouse/ch-node-utils": "^1.3.17",
                 "@companieshouse/node-session-handler": "^5.2.0",
                 "@companieshouse/structured-logging-node": "^2.0.1",
@@ -694,12 +694,11 @@
             }
         },
         "node_modules/@companieshouse/api-sdk-node": {
-            "version": "2.0.243",
-            "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.243.tgz",
-            "integrity": "sha512-V+ZgVflZGpZCEGBS3/Gi7BwWxVLz64KpAhp5WeyKwzpEA54lQ7gvp0Xq05cIGruC2UdPfUyx22axFHgyKAx/Yg==",
+            "version": "0.0.0",
+            "resolved": "git+ssh://git@github.com/companieshouse/api-sdk-node.git#cf473333ba04fbb6bd83556e47b1e10f72e13e97",
             "license": "MIT",
             "dependencies": {
-                "axios": "^1.7.4",
+                "axios": "^1.8.2",
                 "camelcase-keys": "~6.2.2",
                 "http-status-codes": "^2.3.0",
                 "snakecase-keys": "~3.2.0",
@@ -3291,9 +3290,9 @@
             }
         },
         "node_modules/axios": {
-            "version": "1.7.9",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
-            "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+            "version": "1.8.3",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.3.tgz",
+            "integrity": "sha512-iP4DebzoNlP/YN2dpwCgb8zoCmhtkajzS48JvwmkSkXvPI3DHc7m+XYL5tGnSlJtR6nImXZmdCuN5aP8dh1d8A==",
             "license": "MIT",
             "dependencies": {
                 "follow-redirects": "^1.15.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "license": "MIT",
             "dependencies": {
-                "@companieshouse/api-sdk-node": "github:companieshouse/api-sdk-node#feature/add-psc-verification-state-endpoint",
+                "@companieshouse/api-sdk-node": "^2.0.249",
                 "@companieshouse/ch-node-utils": "^1.3.17",
                 "@companieshouse/node-session-handler": "^5.2.0",
                 "@companieshouse/structured-logging-node": "^2.0.1",
@@ -694,8 +694,9 @@
             }
         },
         "node_modules/@companieshouse/api-sdk-node": {
-            "version": "0.0.0",
-            "resolved": "git+ssh://git@github.com/companieshouse/api-sdk-node.git#2a215202817a5c25040153c132487ae3b28cbf2a",
+            "version": "2.0.249",
+            "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.249.tgz",
+            "integrity": "sha512-r+fXekjnnHVN0/YaZVFC8VDZ6G42iBCC4XKwujIe6WP34np2l7cappfUfYtZe18+tC1Zyb2jBmuPVUFaBbzeVw==",
             "license": "MIT",
             "dependencies": {
                 "axios": "^1.8.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -695,7 +695,7 @@
         },
         "node_modules/@companieshouse/api-sdk-node": {
             "version": "0.0.0",
-            "resolved": "git+ssh://git@github.com/companieshouse/api-sdk-node.git#cf473333ba04fbb6bd83556e47b1e10f72e13e97",
+            "resolved": "git+ssh://git@github.com/companieshouse/api-sdk-node.git#2a215202817a5c25040153c132487ae3b28cbf2a",
             "license": "MIT",
             "dependencies": {
                 "axios": "^1.8.2",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "author": "Moses Wejuli <mwejuli@companieshouse.gov.uk>",
     "license": "MIT",
     "dependencies": {
-        "@companieshouse/api-sdk-node": "^2.0.243",
+        "@companieshouse/api-sdk-node": "^2.0.249",
         "@companieshouse/ch-node-utils": "^1.3.17",
         "@companieshouse/node-session-handler": "^5.2.0",
         "@companieshouse/structured-logging-node": "^2.0.1",

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -10,7 +10,7 @@ export const env = readEnv(process.env, {
     CDN_URL_CSS: str.describe("CDN URL for the CSS files"),
     CDN_URL_JS: str.describe("CDN URL for the JavaScript files"),
     CH_NODE_UTILS_LOG_LVL: str.describe("Enable the logging within ch-node-utils for localisation"),
-    CHS_API_KEY: str.describe("API key for CHS service"),
+    CHS_INTERNAL_API_KEY: str.describe("API key for CHS service"),
     CHS_URL: url.describe("This host URL for CHS"),
     CONTACT_US_LINK: str.describe("Link to contact us"),
     COOKIE_DOMAIN: str.describe("Domain for cookies"),

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -10,7 +10,7 @@ export const env = readEnv(process.env, {
     CDN_URL_CSS: str.describe("CDN URL for the CSS files"),
     CDN_URL_JS: str.describe("CDN URL for the JavaScript files"),
     CH_NODE_UTILS_LOG_LVL: str.describe("Enable the logging within ch-node-utils for localisation"),
-    CHS_INTERNAL_API_KEY: str.describe("API key for CHS service"),
+    CHS_INTERNAL_API_KEY: str.describe("Internal API key"),
     CHS_URL: url.describe("This host URL for CHS"),
     CONTACT_US_LINK: str.describe("Link to contact us"),
     COOKIE_DOMAIN: str.describe("Domain for cookies"),

--- a/src/routers/handlers/individual-psc-list/individualPscListHandler.ts
+++ b/src/routers/handlers/individual-psc-list/individualPscListHandler.ts
@@ -8,7 +8,6 @@ import { BaseViewData, GenericHandler, ViewModel } from "../generic";
 import { formatDateBorn, internationaliseDate } from "../../utils";
 import { env } from "../../../config";
 import { logger } from "../../../lib/logger";
-import { getPscIndividual } from "../../../services/pscService";
 
 interface PscListData {
     pscId: string,
@@ -65,24 +64,6 @@ export class IndividualPscListHandler extends GenericHandler<IndividualPscListVi
 
         const exclusivelySuperSecure = allPscDetails.length > 0 && (allSuperSecure && !allCeased);
         const showNoPscsMessage = allPscDetails.length === 0 || allCeased;
-
-        // TODO - use/display the verification state data in the PSC list page
-        // Temporary block to retrieve a single PSC verification state when running in Docker and CHIPS cidev
-        if (allPscDetails && allPscDetails.length > 0) {
-            const notificationId = "PSCDATA5";
-            const pscId = "PSCDATA5";
-            const pscData = allPscDetails.find(item => item.pscId === pscId);
-            let pscWithVerificationState;
-
-            if (pscData) {
-                try {
-                    pscWithVerificationState = await getPscIndividual(companyNumber, notificationId);
-                    logger.debug(`PSC with verification state: ${JSON.stringify(pscWithVerificationState)}`);
-                } catch (err: any) {
-                    logger.error(`${req.method} error: problem calling getPscVerificationState request: ${err.message}`);
-                }
-            }
-        }
 
         return {
             ...baseViewData,

--- a/src/routers/handlers/individual-psc-list/individualPscListHandler.ts
+++ b/src/routers/handlers/individual-psc-list/individualPscListHandler.ts
@@ -8,6 +8,8 @@ import { BaseViewData, GenericHandler, ViewModel } from "../generic";
 import { formatDateBorn, internationaliseDate } from "../../utils";
 import { env } from "../../../config";
 import { logger } from "../../../lib/logger";
+import { getPscVerificationState } from "../../../services/pscService";
+import { PscVerificationState } from "@companieshouse/api-sdk-node/dist/services/psc/types";
 
 interface PscListData {
     pscId: string,
@@ -64,6 +66,13 @@ export class IndividualPscListHandler extends GenericHandler<IndividualPscListVi
 
         const exclusivelySuperSecure = allPscDetails.length > 0 && (allSuperSecure && !allCeased);
         const showNoPscsMessage = allPscDetails.length === 0 || allCeased;
+
+        // TODO - implement as separate ticket to use/display the verification state data
+        // Temporary update to retrieve the PSC verification state data
+        if (allPscDetails && allPscDetails.length > 0) {
+            const verificationState = getPscVerificationState(req, allPscDetails[0].pscId) as unknown as PscVerificationState;
+            logger.debug(`${verificationState}`);
+        }
 
         return {
             ...baseViewData,

--- a/src/routers/handlers/individual-psc-list/individualPscListHandler.ts
+++ b/src/routers/handlers/individual-psc-list/individualPscListHandler.ts
@@ -8,8 +8,7 @@ import { BaseViewData, GenericHandler, ViewModel } from "../generic";
 import { formatDateBorn, internationaliseDate } from "../../utils";
 import { env } from "../../../config";
 import { logger } from "../../../lib/logger";
-import { getPscVerificationState } from "../../../services/pscService";
-import { PscVerificationState } from "@companieshouse/api-sdk-node/dist/services/psc/types";
+import { getPscIndWithVerificationState } from "../../../services/pscService";
 
 interface PscListData {
     pscId: string,
@@ -67,11 +66,22 @@ export class IndividualPscListHandler extends GenericHandler<IndividualPscListVi
         const exclusivelySuperSecure = allPscDetails.length > 0 && (allSuperSecure && !allCeased);
         const showNoPscsMessage = allPscDetails.length === 0 || allCeased;
 
-        // TODO - implement as separate ticket to use/display the verification state data
-        // Temporary update to retrieve the PSC verification state data
+        // TODO - use/display the verification state data in the PSC list page
+        // Temporary block to retrieve a single PSC verification state when running in Docker and CHIPS cidev
         if (allPscDetails && allPscDetails.length > 0) {
-            const verificationState = getPscVerificationState(req, allPscDetails[0].pscId) as unknown as PscVerificationState;
-            logger.debug(`${verificationState}`);
+            const notificationId = "PSCDATA5";
+            const pscId = "PSCDATA5";
+            const pscData = allPscDetails.find(item => item.pscId === pscId);
+            let pscWithVerificationState;
+
+            if (pscData) {
+                try {
+                    pscWithVerificationState = await getPscIndWithVerificationState(companyNumber, notificationId);
+                    logger.debug(`PSC with verification state: ${JSON.stringify(pscWithVerificationState)}`);
+                } catch (err: any) {
+                    logger.error(`${req.method} error: problem calling getPscVerificationState request: ${err.message}`);
+                }
+            }
         }
 
         return {

--- a/src/routers/handlers/individual-psc-list/individualPscListHandler.ts
+++ b/src/routers/handlers/individual-psc-list/individualPscListHandler.ts
@@ -8,7 +8,7 @@ import { BaseViewData, GenericHandler, ViewModel } from "../generic";
 import { formatDateBorn, internationaliseDate } from "../../utils";
 import { env } from "../../../config";
 import { logger } from "../../../lib/logger";
-import { getPscIndWithVerificationState } from "../../../services/pscService";
+import { getPscIndividual } from "../../../services/pscService";
 
 interface PscListData {
     pscId: string,
@@ -76,7 +76,7 @@ export class IndividualPscListHandler extends GenericHandler<IndividualPscListVi
 
             if (pscData) {
                 try {
-                    pscWithVerificationState = await getPscIndWithVerificationState(companyNumber, notificationId);
+                    pscWithVerificationState = await getPscIndividual(companyNumber, notificationId);
                     logger.debug(`PSC with verification state: ${JSON.stringify(pscWithVerificationState)}`);
                 } catch (err: any) {
                     logger.error(`${req.method} error: problem calling getPscVerificationState request: ${err.message}`);

--- a/src/routers/handlers/individual-statement/individualStatementHandler.ts
+++ b/src/routers/handlers/individual-statement/individualStatementHandler.ts
@@ -26,7 +26,7 @@ export class IndividualStatementHandler extends GenericHandler<IndividualStateme
 
         const baseViewData = await super.getViewData(req, res);
         const verification = res.locals.submission;
-        const pscDetailsResponse = await getPscIndividual(req, verification?.data.companyNumber as string, verification?.data.pscNotificationId as string);
+        const pscDetailsResponse = await getPscIndividual(verification?.data.companyNumber as string, verification?.data.pscNotificationId as string);
         const lang = selectLang(req.query.lang);
         const locales = getLocalesService();
         const selectedStatements = verification?.data?.verificationDetails?.verificationStatements || [];

--- a/src/routers/handlers/name-mismatch/nameMismatchHandler.ts
+++ b/src/routers/handlers/name-mismatch/nameMismatchHandler.ts
@@ -32,7 +32,7 @@ export class NameMismatchHandler extends GenericHandler<NameMismatchViewData> {
         const baseViewData = await super.getViewData(req, res);
         const verification: PscVerification = res.locals.submission;
         const companyNumber = verification.data.companyNumber as string;
-        const pscIndividual = await getPscIndividual(req, companyNumber, verification.data.pscNotificationId as string);
+        const pscIndividual = await getPscIndividual(companyNumber, verification.data.pscNotificationId as string);
         const nameMismatch = verification.data.verificationDetails?.nameMismatchReason ?? "" as string;
         const lang = selectLang(req.query.lang);
         const locales = getLocalesService();

--- a/src/routers/handlers/personal-code/personalCodeHandler.ts
+++ b/src/routers/handlers/personal-code/personalCodeHandler.ts
@@ -31,7 +31,7 @@ export class PersonalCodeHandler extends GenericHandler<PersonalCodeViewData> {
         const baseViewData = await super.getViewData(req, res);
         const verification: PscVerification = res.locals.submission;
         const companyNumber = verification.data.companyNumber as string;
-        const pscIndividual = await getPscIndividual(req, companyNumber, verification.data.pscNotificationId as string);
+        const pscIndividual = await getPscIndividual(companyNumber, verification.data.pscNotificationId as string);
         const lang = selectLang(req.query.lang);
         const locales = getLocalesService();
 

--- a/src/routers/handlers/psc-verified/pscVerifiedHandler.ts
+++ b/src/routers/handlers/psc-verified/pscVerifiedHandler.ts
@@ -32,7 +32,7 @@ export class PscVerifiedHandler extends GenericHandler<PscVerifiedViewData> {
         const companyNumber = verification?.data?.companyNumber as string;
         const companyProfile = res.locals.companyProfile;
         const pscNotificationId = verification?.data.pscNotificationId as string;
-        const pscDetailsResponse = await getPscIndividual(req, companyNumber, pscNotificationId);
+        const pscDetailsResponse = await getPscIndividual(companyNumber, pscNotificationId);
         const companyName = companyProfile.companyName as string;
         const forward = decodeURI(addSearchParams(ExternalUrls.COMPANY_LOOKUP_FORWARD, { companyNumber: "{companyNumber}", lang }));
 

--- a/src/services/apiClientService.ts
+++ b/src/services/apiClientService.ts
@@ -10,5 +10,5 @@ export const createOAuthApiClient = (session: Session | undefined, baseUrl: stri
 };
 
 export const createApiKeyClient = (): ApiClient => {
-    return createApiClient(env.CHS_API_KEY, undefined, env.API_URL);
+    return createApiClient(env.CHS_INTERNAL_API_KEY, undefined, env.API_URL);
 };

--- a/src/services/pscService.ts
+++ b/src/services/pscService.ts
@@ -12,8 +12,8 @@ export const getPscIndividual = async (companyNumber: string, pscNotificationId:
     logger.debug(`${getPscIndividual.name} - for companyNumber: ${companyNumber} and PSC notification ID: ${pscNotificationId}`);
     const sdkResponse: Resource<PersonWithSignificantControl> | ApiErrorResponse = await apiClient.pscService.getPscIndividual(companyNumber, pscNotificationId);
 
-    if (!sdkResponse || !sdkResponse.httpStatusCode || sdkResponse.httpStatusCode !== HttpStatusCode.Ok) {
-        if (sdkResponse && sdkResponse.httpStatusCode) {
+    if (sdkResponse?.httpStatusCode !== HttpStatusCode.Ok) {
+        if (sdkResponse?.httpStatusCode) {
             logger.error(`${getPscIndividual.name} - sdk responded with HTTP status code: ${sdkResponse.httpStatusCode}`);
         }
         throw createAndLogError(`${getPscIndividual.name} -  Failed to get PSC with verification state for companyNumber: ${companyNumber} and PSC notification ID: ${pscNotificationId}`);

--- a/src/services/pscService.ts
+++ b/src/services/pscService.ts
@@ -1,51 +1,29 @@
 import { Resource } from "@companieshouse/api-sdk-node";
 import ApiClient from "@companieshouse/api-sdk-node/dist/client";
-import { PersonWithSignificantControl, PscIndWithVerificationState } from "@companieshouse/api-sdk-node/dist/services/psc/types";
+import { PersonWithSignificantControl } from "@companieshouse/api-sdk-node/dist/services/psc/types";
 import { ApiErrorResponse } from "@companieshouse/api-sdk-node/dist/services/resource";
 import { HttpStatusCode } from "axios";
-import { Request } from "express";
 import { createAndLogError, logger } from "../lib/logger";
-import { createApiKeyClient, createOAuthApiClient } from "./apiClientService";
+import { createApiKeyClient } from "./apiClientService";
 
-export const getPscIndividual = async (request: Request, companyNumber: string, pscId: string): Promise<Resource<PersonWithSignificantControl>> => {
-    const oAuthApiClient: ApiClient = createOAuthApiClient(request.session);
+export const getPscIndividual = async (companyNumber: string, pscNotificationId: string): Promise<Resource<PersonWithSignificantControl>> => {
+    const apiClient: ApiClient = createApiKeyClient();
 
-    logger.debug(`${getPscIndividual.name} - for PSC ID: ${pscId}`);
-    const sdkResponse: Resource<PersonWithSignificantControl> | ApiErrorResponse = await oAuthApiClient.pscService.getPscIndividual(companyNumber, pscId);
+    logger.debug(`${getPscIndividual.name} - for companyNumber: ${companyNumber} and PSC notification ID: ${pscNotificationId}`);
+    const sdkResponse: Resource<PersonWithSignificantControl> | ApiErrorResponse = await apiClient.pscService.getPscIndividual(companyNumber, pscNotificationId);
 
     if (!sdkResponse || !sdkResponse.httpStatusCode || sdkResponse.httpStatusCode !== HttpStatusCode.Ok) {
-        throw createAndLogError(`${getPscIndividual.name} - Failed to get details for PSC Id  ${pscId}`);
+        if (sdkResponse && sdkResponse.httpStatusCode) {
+            logger.error(`${getPscIndividual.name} - sdk responded with HTTP status code: ${sdkResponse.httpStatusCode}`);
+        }
+        throw createAndLogError(`${getPscIndividual.name} -  Failed to get PSC with verification state for companyNumber: ${companyNumber} and PSC notification ID: ${pscNotificationId}`);
     }
 
     logger.debug(`${getPscIndividual.name} - response: ${JSON.stringify(sdkResponse)}`);
     const PscSdkResponse = sdkResponse as Resource<PersonWithSignificantControl>;
 
     if (!PscSdkResponse.resource) {
-        throw createAndLogError(`${getPscIndividual.name} - no resource returned for PSC Id ${pscId}`);
-    }
-
-    return PscSdkResponse;
-};
-
-export const getPscIndWithVerificationState = async (companyNumber: string, pscNotificationId: string): Promise<Resource<PscIndWithVerificationState>> => {
-    const apiClient: ApiClient = createApiKeyClient();
-
-    logger.debug(`${getPscIndWithVerificationState.name} - for companyNumber: ${companyNumber} and PSC notification ID: ${pscNotificationId}`);
-
-    const sdkResponse: Resource<PscIndWithVerificationState> | ApiErrorResponse = await apiClient.pscService.getPscIndWithVerificationState(companyNumber, pscNotificationId);
-
-    if (!sdkResponse || !sdkResponse.httpStatusCode || sdkResponse.httpStatusCode !== HttpStatusCode.Ok) {
-        if (sdkResponse && sdkResponse.httpStatusCode) {
-            logger.error(`${getPscIndWithVerificationState.name} - sdk responded with HTTP status code: ${sdkResponse.httpStatusCode}`);
-        }
-        throw createAndLogError(`${getPscIndWithVerificationState.name} -  Failed to get PSC with verification state for companyNumber: ${companyNumber} and PSC notification ID: ${pscNotificationId}`);
-    }
-
-    logger.debug(`${getPscIndWithVerificationState.name} - response: ${JSON.stringify(sdkResponse)}`);
-    const PscSdkResponse = sdkResponse as Resource<PscIndWithVerificationState>;
-
-    if (!PscSdkResponse.resource) {
-        throw createAndLogError(`${getPscIndWithVerificationState.name} - no PSC with verification state returned for companyNumber: ${companyNumber} and PSC notification ID: ${pscNotificationId}`);
+        throw createAndLogError(`${getPscIndividual.name} - no PSC with verification state returned for companyNumber: ${companyNumber} and PSC notification ID: ${pscNotificationId}`);
     }
 
     return PscSdkResponse;

--- a/test/middleware/checkCompany.int.ts
+++ b/test/middleware/checkCompany.int.ts
@@ -17,6 +17,8 @@ jest.mock("../../src/services/companyPscService");
 const mockGetCompanyIndividualPscList = getCompanyIndividualPscList as jest.Mock;
 mockGetCompanyIndividualPscList.mockResolvedValueOnce(INDIVIDUAL_PSCS_LIST);
 
+jest.mock("../../src/services/pscService");
+
 describe("CheckCompany middleware", () => {
 
     beforeEach(() => {

--- a/test/mocks/psc.mock.ts
+++ b/test/mocks/psc.mock.ts
@@ -4,6 +4,12 @@ import { PSC_KIND_TYPE } from "../../src/constants";
 export const COMPANY_NUMBER = "12345678";
 export const PSC_ID = "67edfE436y35hetsie6zuAZtr";
 
+const PSC_VERIFICATION_STATE: PscVerificationState = {
+    verificationStatus: VerificationStatusEnum.UNVERIFIED,
+    verificationStartDate: new Date("2024-04-13"),
+    verificationStatementDueDate: new Date("2024-04-27")
+};
+
 export const PSC_INDIVIDUAL: PersonWithSignificantControl = {
     naturesOfControl: ["ownership-of-shares-75-to-100-percent", "voting-rights-75-to-100-percent-as-trust"],
     kind: PSC_KIND_TYPE.INDIVIDUAL,
@@ -19,19 +25,14 @@ export const PSC_INDIVIDUAL: PersonWithSignificantControl = {
         postalCode: "CF14 3UZ",
         locality: "Cardiff",
         region: "South Glamorgan",
-        addressLine: "Crown Way"
+        addressLine1: "Crown Way"
     },
     countryOfResidence: "Wales",
     links: {
         self: `/company/${COMPANY_NUMBER}/persons-with-significant-control/individual/${PSC_ID}`
     },
     dateOfBirth: { year: "2000", month: "04" },
-    etag: "",
-    notifiedOn: ""
-};
-
-export const PSC_VERIFICATION_STATE: PscVerificationState = {
-    verificationStatus: VerificationStatusEnum.UNVERIFIED,
-    verificationStartDate: new Date("2024-04-13"),
-    verificationStatementDueDate: new Date("2024-04-27")
+    etag: "etag",
+    notifiedOn: "2023-01-31",
+    verificationState: PSC_VERIFICATION_STATE
 };

--- a/test/mocks/psc.mock.ts
+++ b/test/mocks/psc.mock.ts
@@ -1,4 +1,4 @@
-import { PersonWithSignificantControl } from "@companieshouse/api-sdk-node/dist/services/psc/types";
+import { PersonWithSignificantControl, PscVerificationState, VerificationStatusEnum } from "@companieshouse/api-sdk-node/dist/services/psc/types";
 import { PSC_KIND_TYPE } from "../../src/constants";
 
 export const COMPANY_NUMBER = "12345678";
@@ -28,4 +28,10 @@ export const PSC_INDIVIDUAL: PersonWithSignificantControl = {
     dateOfBirth: { year: "2000", month: "04" },
     etag: "",
     notifiedOn: ""
+};
+
+export const PSC_VERIFICATION_STATE: PscVerificationState = {
+    verificationStatus: VerificationStatusEnum.UNVERIFIED,
+    verificationStartDate: new Date("2024-04-13"),
+    verificationStatementDueDate: new Date("2024-04-27")
 };

--- a/test/routers/handlers/individual-psc-list/individualPscListHandler.int.ts
+++ b/test/routers/handlers/individual-psc-list/individualPscListHandler.int.ts
@@ -18,6 +18,7 @@ mockGetCompanyProfile.mockResolvedValueOnce(validCompanyProfile);
 jest.mock("../../../../src/services/companyPscService");
 const mockGetCompanyIndividualPscList = getCompanyIndividualPscList as jest.Mock;
 mockGetCompanyIndividualPscList.mockResolvedValueOnce(INDIVIDUAL_PSCS_LIST);
+jest.mock("../../../../src/services/pscService");
 
 describe("individual PSC list view", () => {
 

--- a/test/routers/handlers/individual-psc-list/individualPscListHandler.unit.ts
+++ b/test/routers/handlers/individual-psc-list/individualPscListHandler.unit.ts
@@ -23,6 +23,8 @@ mockGetCompanyProfile.mockResolvedValue(validCompanyProfile);
 jest.mock("../../../../src/services/companyPscService");
 const mockGetCompanyIndividualPscList = getCompanyIndividualPscList as jest.Mock;
 
+jest.mock("../../../../src/services/pscService");
+
 describe("psc list handler", () => {
 
     afterEach(() => {

--- a/test/routers/handlers/psc-verified/pscVerified.int.ts
+++ b/test/routers/handlers/psc-verified/pscVerified.int.ts
@@ -68,7 +68,7 @@ describe("psc verified view tests", () => {
         expect(mockGetCompanyProfile).toHaveBeenCalledTimes(1);
         expect(mockGetCompanyProfile).toHaveBeenCalledWith(expect.any(IncomingMessage), COMPANY_NUMBER);
         expect(mockGetPscIndividual).toHaveBeenCalledTimes(1);
-        expect(mockGetPscIndividual).toHaveBeenCalledWith(expect.any(IncomingMessage), COMPANY_NUMBER, PSC_NOTIFICATION_ID);
+        expect(mockGetPscIndividual).toHaveBeenCalledWith(COMPANY_NUMBER, PSC_NOTIFICATION_ID);
 
     });
 });

--- a/test/routers/handlers/psc-verified/pscVerifiedHandler.unit.ts
+++ b/test/routers/handlers/psc-verified/pscVerifiedHandler.unit.ts
@@ -72,7 +72,7 @@ describe("PSC Verified handler", () => {
             expect(mockGetPscVerification).not.toHaveBeenCalled();
             expect(mockGetCompanyProfile).not.toHaveBeenCalled();
             expect(mockGetPscIndividual).toHaveBeenCalledTimes(1);
-            expect(mockGetPscIndividual).toHaveBeenCalledWith(request, COMPANY_NUMBER, PSC_NOTIFICATION_ID);
+            expect(mockGetPscIndividual).toHaveBeenCalledWith(COMPANY_NUMBER, PSC_NOTIFICATION_ID);
             expect(mockCloseTransaction).toHaveBeenCalledTimes(1);
             expect(mockCloseTransaction).toHaveBeenCalledWith(request, TRANSACTION_ID, PSC_VERIFICATION_ID);
 

--- a/test/routers/individualPscListRouter.int.ts
+++ b/test/routers/individualPscListRouter.int.ts
@@ -18,6 +18,8 @@ mockGetCompanyProfile.mockResolvedValue(validCompanyProfile);
 jest.mock("../../src/services/companyPscService");
 const mockGetCompanyIndividualPscList = getCompanyIndividualPscList as jest.Mock;
 
+jest.mock("../../src/services/pscService");
+
 describe("GET psc individual list router", () => {
     beforeEach(() => {
     });

--- a/test/services/apiClientService.unit.ts
+++ b/test/services/apiClientService.unit.ts
@@ -34,7 +34,7 @@ describe("createApiKeyClient", () => {
         const client = createApiKeyClient();
 
         expect(client).not.toBeNull();
-        expect(createApiClient).toHaveBeenCalledWith(process.env.CHS_API_KEY, undefined, process.env.API_URL);
+        expect(createApiClient).toHaveBeenCalledWith(process.env.CHS_INTERNAL_API_KEY, undefined, process.env.API_URL);
     });
 
 });

--- a/test/services/pscService.unit.ts
+++ b/test/services/pscService.unit.ts
@@ -1,73 +1,128 @@
-import { PersonWithSignificantControl } from "@companieshouse/api-sdk-node/dist/services/psc/types";
-import { ApiResponse } from "@companieshouse/api-sdk-node/dist/services/resource";
-import { Session } from "@companieshouse/node-session-handler";
+import { PersonWithSignificantControl, PscVerificationState } from "@companieshouse/api-sdk-node/dist/services/psc/types";
+import Resource, { ApiResponse } from "@companieshouse/api-sdk-node/dist/services/resource";
 import { HttpStatusCode } from "axios";
 import { Request } from "express";
 import { createOAuthApiClient } from "../../src/services/apiClientService";
-import { getPscIndividual } from "../../src/services/pscService";
-import { COMPANY_NUMBER, PSC_ID, PSC_INDIVIDUAL } from "../mocks/psc.mock";
+import { getPscIndividual, getPscVerificationState } from "../../src/services/pscService";
+import { COMPANY_NUMBER, PSC_ID, PSC_INDIVIDUAL, PSC_VERIFICATION_STATE } from "../mocks/psc.mock";
+import { PSC_NOTIFICATION_ID } from "../mocks/pscVerification.mock";
 
 jest.mock("@companieshouse/api-sdk-node");
 jest.mock("../../src/services/apiClientService");
 
 const mockGetPscIndividual = jest.fn();
+const mockGetPscVerificationState = jest.fn();
 const mockCreateOAuthApiClient = createOAuthApiClient as jest.Mock;
-let session: Session;
 
 mockCreateOAuthApiClient.mockReturnValue({
     pscService: {
-        getPscIndividual: mockGetPscIndividual
+        getPscIndividual: mockGetPscIndividual,
+        getPscVerificationState: mockGetPscVerificationState
     }
 });
 
-describe("pscServiceIndividual", () => {
+describe("PSC Service", () => {
+    const request = {} as Request;
+
     beforeEach(() => {
         jest.clearAllMocks();
-        session = new Session();
     });
-    it("getPscIndividual should return 200 OK HttpStatus response", async () => {
-        const mockResponse: ApiResponse<PersonWithSignificantControl> = {
-            httpStatusCode: HttpStatusCode.Ok,
-            resource: PSC_INDIVIDUAL
-        };
-        mockGetPscIndividual.mockResolvedValueOnce(mockResponse as ApiResponse<PersonWithSignificantControl>);
-        const request = {} as Request;
 
-        const response = await getPscIndividual(request, COMPANY_NUMBER, PSC_ID);
+    describe("getPscIndividual", () => {
 
-        const resource = response.resource as PersonWithSignificantControl;
-        expect(response.httpStatusCode).toBe(HttpStatusCode.Ok);
-        expect(resource).toEqual(PSC_INDIVIDUAL);
-        expect(mockCreateOAuthApiClient).toHaveBeenCalledTimes(1);
-        expect(mockGetPscIndividual).toHaveBeenCalledTimes(1);
-        expect(mockGetPscIndividual).toHaveBeenCalledWith(COMPANY_NUMBER, PSC_ID);
+        it("getPscIndividual should return 200 OK HttpStatus response", async () => {
+            const mockResponse: ApiResponse<PersonWithSignificantControl> = {
+                httpStatusCode: HttpStatusCode.Ok,
+                resource: PSC_INDIVIDUAL
+            };
+            mockGetPscIndividual.mockResolvedValueOnce(mockResponse as ApiResponse<PersonWithSignificantControl>);
 
-    });
-    it("getPscIndividual should throw an error if HttpStatus is not 200 OK", async () => {
-        const mockResponse: ApiResponse<PersonWithSignificantControl> = {
-            httpStatusCode: HttpStatusCode.ServiceUnavailable
-        };
-        mockGetPscIndividual.mockResolvedValueOnce(mockResponse as ApiResponse<PersonWithSignificantControl>);
-        const request = {} as Request;
-
-        try {
             const response = await getPscIndividual(request, COMPANY_NUMBER, PSC_ID);
-            throw new Error("invalid expecting getPscIndividual to throw error");
-        } catch (error: any) {
-            expect(error.message).toBe("getPscIndividual - Failed to get details for PSC Id  67edfE436y35hetsie6zuAZtr");
-        }
+
+            const resource = response.resource as PersonWithSignificantControl;
+            expect(response.httpStatusCode).toBe(HttpStatusCode.Ok);
+            expect(resource).toEqual(PSC_INDIVIDUAL);
+            expect(mockCreateOAuthApiClient).toHaveBeenCalledTimes(1);
+            expect(mockGetPscIndividual).toHaveBeenCalledTimes(1);
+            expect(mockGetPscIndividual).toHaveBeenCalledWith(COMPANY_NUMBER, PSC_ID);
+
+        });
+        it("getPscIndividual should throw an error if HttpStatus is not 200 OK", async () => {
+            const mockResponse: ApiResponse<PersonWithSignificantControl> = {
+                httpStatusCode: HttpStatusCode.ServiceUnavailable
+            };
+            mockGetPscIndividual.mockResolvedValueOnce(mockResponse as ApiResponse<PersonWithSignificantControl>);
+
+            try {
+                const response = await getPscIndividual(request, COMPANY_NUMBER, PSC_ID);
+                throw new Error("invalid expecting getPscIndividual to throw error");
+            } catch (error: any) {
+                expect(error.message).toBe("getPscIndividual - Failed to get details for PSC Id  67edfE436y35hetsie6zuAZtr");
+            }
+        });
+        it("getPscIndividual should throw an error if no resource is returned", async () => {
+            const mockResponse: ApiResponse<PersonWithSignificantControl> = {
+                httpStatusCode: HttpStatusCode.Ok
+            };
+            mockGetPscIndividual.mockResolvedValueOnce(mockResponse as ApiResponse<PersonWithSignificantControl>);
+            try {
+                await getPscIndividual(request, COMPANY_NUMBER, PSC_ID);
+                throw new Error("invalid expecting getPscIndividual to throw error");
+            } catch (error: any) {
+                expect(error.message).toBe("getPscIndividual - no resource returned for PSC Id 67edfE436y35hetsie6zuAZtr");
+            }
+        });
     });
-    it("getPscIndividual should throw an error if no resource is returned", async () => {
-        const mockResponse: ApiResponse<PersonWithSignificantControl> = {
-            httpStatusCode: HttpStatusCode.Ok
-        };
-        mockGetPscIndividual.mockResolvedValueOnce(mockResponse as ApiResponse<PersonWithSignificantControl>);
-        const request = {} as Request;
-        try {
-            await getPscIndividual(request, COMPANY_NUMBER, PSC_ID);
-            throw new Error("invalid expecting getPscIndividual to throw error");
-        } catch (error: any) {
-            expect(error.message).toBe("getPscIndividual - no resource returned for PSC Id 67edfE436y35hetsie6zuAZtr");
-        }
+
+    describe("getPscVerificationState as POST endpoint", () => {
+
+        it("should retrieve the resource by its ID", async () => {
+            const mockPost: Resource<PscVerificationState> = {
+                httpStatusCode: HttpStatusCode.Ok,
+                resource: PSC_VERIFICATION_STATE
+            };
+
+            mockGetPscVerificationState.mockResolvedValueOnce(mockPost);
+
+            const response = await getPscVerificationState(request, PSC_NOTIFICATION_ID);
+
+            const resource = response.resource as PscVerificationState;
+            expect(response.httpStatusCode).toBe(HttpStatusCode.Ok);
+            expect(resource).toEqual(PSC_VERIFICATION_STATE);
+            expect(mockCreateOAuthApiClient).toHaveBeenCalledTimes(1);
+            expect(mockGetPscVerificationState).toHaveBeenCalledTimes(1);
+            expect(mockGetPscVerificationState).toHaveBeenCalledWith(PSC_NOTIFICATION_ID);
+        });
+
+        it("should throw an error when the response resource is empty", async () => {
+            const mockGet: Resource<PscVerificationState> = {
+                httpStatusCode: HttpStatusCode.Ok,
+                resource: undefined
+            };
+
+            mockGetPscVerificationState.mockResolvedValueOnce(mockGet);
+
+            await expect(getPscVerificationState(request, PSC_NOTIFICATION_ID)).rejects.toThrow(
+                new Error(`getPscVerificationState - no resource returned for PSC notification ID: ${PSC_NOTIFICATION_ID}`));
+        });
+
+        it("should throw an Error when no response from API", async () => {
+            mockGetPscVerificationState.mockResolvedValueOnce(undefined);
+            const request = {} as Request;
+
+            await expect(getPscVerificationState(request, PSC_NOTIFICATION_ID)).rejects.toThrow(
+                new Error(`getPscVerificationState - Failed to get verification status for PSC notification ID: ${PSC_NOTIFICATION_ID}`));
+        });
+        it("should throw an Error when API status is unavailable", async () => {
+            const mockGet: Resource<PscVerificationState> = {
+                httpStatusCode: HttpStatusCode.ServiceUnavailable
+            };
+
+            mockGetPscVerificationState.mockResolvedValueOnce(mockGet);
+
+            await expect(getPscVerificationState(request, PSC_NOTIFICATION_ID)).rejects.toThrow(
+                new Error(`getPscVerificationState - Failed to get verification status for PSC notification ID: ${PSC_NOTIFICATION_ID}`));
+        });
+
     });
 });

--- a/test/services/pscService.unit.ts
+++ b/test/services/pscService.unit.ts
@@ -1,132 +1,90 @@
-import { PersonWithSignificantControl, PscIndWithVerificationState, PscIndWithVerificationStateResource } from "@companieshouse/api-sdk-node/dist/services/psc/types";
+import { PersonWithSignificantControl, PersonWithSignificantControlResource } from "@companieshouse/api-sdk-node/dist/services/psc/types";
 import Resource, { ApiResponse } from "@companieshouse/api-sdk-node/dist/services/resource";
 import { HttpStatusCode } from "axios";
-import { Request } from "express";
-import { createApiKeyClient, createOAuthApiClient } from "../../src/services/apiClientService";
-import { getPscIndWithVerificationState, getPscIndividual } from "../../src/services/pscService";
-import { COMPANY_NUMBER, PSC_ID, PSC_INDIVIDUAL, PSC_VERIFICATION_STATE } from "../mocks/psc.mock";
+import { createApiKeyClient } from "../../src/services/apiClientService";
+import { getPscIndividual } from "../../src/services/pscService";
+import { COMPANY_NUMBER, PSC_ID, PSC_INDIVIDUAL } from "../mocks/psc.mock";
 import { PSC_NOTIFICATION_ID } from "../mocks/pscVerification.mock";
 
 jest.mock("@companieshouse/api-sdk-node");
 jest.mock("../../src/services/apiClientService");
 
 const mockGetPscIndividual = jest.fn();
-const mockGetPscIndWithVerificationState = jest.fn();
-const mockCreateOAuthApiClient = createOAuthApiClient as jest.Mock;
 
-mockCreateOAuthApiClient.mockReturnValue({
+const mockCreateApiKeyClient = createApiKeyClient as jest.Mock;
+mockCreateApiKeyClient.mockReturnValue({
     pscService: {
         getPscIndividual: mockGetPscIndividual
     }
 });
 
-const mockCreateApiKeyClient = createApiKeyClient as jest.Mock;
-mockCreateApiKeyClient.mockReturnValue({
-    pscService: {
-        getPscIndWithVerificationState: mockGetPscIndWithVerificationState
-    }
-});
-
 describe("PSC Service", () => {
-    const request = {} as Request;
 
     beforeEach(() => {
         jest.clearAllMocks();
     });
 
-    describe("getPscIndividual", () => {
+    describe("getPscIndividual endpoint", () => {
 
         it("getPscIndividual should return 200 OK HttpStatus response", async () => {
-            const mockResponse: ApiResponse<PersonWithSignificantControl> = {
+            const mockGet: Resource<PersonWithSignificantControl> = {
                 httpStatusCode: HttpStatusCode.Ok,
                 resource: PSC_INDIVIDUAL
             };
-            mockGetPscIndividual.mockResolvedValueOnce(mockResponse as ApiResponse<PersonWithSignificantControl>);
 
-            const response = await getPscIndividual(request, COMPANY_NUMBER, PSC_ID);
+            mockGetPscIndividual.mockResolvedValueOnce(mockGet);
+            const response = await getPscIndividual(COMPANY_NUMBER, PSC_NOTIFICATION_ID);
 
-            const resource = response.resource as PersonWithSignificantControl;
             expect(response.httpStatusCode).toBe(HttpStatusCode.Ok);
-            expect(resource).toEqual(PSC_INDIVIDUAL);
-            expect(mockCreateOAuthApiClient).toHaveBeenCalledTimes(1);
+            expect(response.resource).toEqual(PSC_INDIVIDUAL);
+            expect(mockCreateApiKeyClient).toHaveBeenCalledTimes(1);
             expect(mockGetPscIndividual).toHaveBeenCalledTimes(1);
-            expect(mockGetPscIndividual).toHaveBeenCalledWith(COMPANY_NUMBER, PSC_ID);
-
+            expect(mockGetPscIndividual).toHaveBeenCalledWith(COMPANY_NUMBER, PSC_NOTIFICATION_ID);
         });
-        it("getPscIndividual should throw an error if HttpStatus is not 200 OK", async () => {
+
+        it("getPscIndividual should throw an Error if HttpStatus is not 200 OK", async () => {
             const mockResponse: ApiResponse<PersonWithSignificantControl> = {
                 httpStatusCode: HttpStatusCode.ServiceUnavailable
             };
+
             mockGetPscIndividual.mockResolvedValueOnce(mockResponse as ApiResponse<PersonWithSignificantControl>);
 
             try {
-                const response = await getPscIndividual(request, COMPANY_NUMBER, PSC_ID);
+                await getPscIndividual(COMPANY_NUMBER, PSC_ID);
                 throw new Error("invalid expecting getPscIndividual to throw error");
             } catch (error: any) {
-                expect(error.message).toBe("getPscIndividual - Failed to get details for PSC Id  67edfE436y35hetsie6zuAZtr");
+                expect(error.message).toBe("getPscIndividual -  Failed to get PSC with verification state for companyNumber: 12345678 and PSC notification ID: 67edfE436y35hetsie6zuAZtr");
             }
         });
-        it("getPscIndividual should throw an error if no resource is returned", async () => {
-            const mockResponse: ApiResponse<PersonWithSignificantControl> = {
-                httpStatusCode: HttpStatusCode.Ok
-            };
-            mockGetPscIndividual.mockResolvedValueOnce(mockResponse as ApiResponse<PersonWithSignificantControl>);
-            try {
-                await getPscIndividual(request, COMPANY_NUMBER, PSC_ID);
-                throw new Error("invalid expecting getPscIndividual to throw error");
-            } catch (error: any) {
-                expect(error.message).toBe("getPscIndividual - no resource returned for PSC Id 67edfE436y35hetsie6zuAZtr");
-            }
-        });
-    });
 
-    describe("getPscIndWithVerificationState endpoint", () => {
-
-        it("should retrieve the resource by its ID", async () => {
-            const mockGet: Resource<PscIndWithVerificationStateResource> = {
-                httpStatusCode: HttpStatusCode.Ok,
-                resource: PSC_VERIFICATION_STATE
-            };
-
-            mockGetPscIndWithVerificationState.mockResolvedValueOnce(mockGet);
-
-            const response = await getPscIndWithVerificationState(COMPANY_NUMBER, PSC_NOTIFICATION_ID);
-
-            const resource = response.resource as PscIndWithVerificationState;
-            expect(response.httpStatusCode).toBe(HttpStatusCode.Ok);
-            expect(resource).toEqual(PSC_VERIFICATION_STATE);
-            expect(mockCreateApiKeyClient).toHaveBeenCalledTimes(1);
-            expect(mockGetPscIndWithVerificationState).toHaveBeenCalledTimes(1);
-            expect(mockGetPscIndWithVerificationState).toHaveBeenCalledWith(COMPANY_NUMBER, PSC_NOTIFICATION_ID);
-        });
-
-        it("should throw an error when the response resource is empty", async () => {
-            const mockGet: Resource<PscIndWithVerificationStateResource> = {
+        it("should throw an Error when the response resource is undefined", async () => {
+            const mockGet: Resource<PersonWithSignificantControl> = {
                 httpStatusCode: HttpStatusCode.Ok,
                 resource: undefined
             };
 
-            mockGetPscIndWithVerificationState.mockResolvedValueOnce(mockGet);
+            mockGetPscIndividual.mockResolvedValueOnce(mockGet);
 
-            await expect(getPscIndWithVerificationState(COMPANY_NUMBER, PSC_NOTIFICATION_ID)).rejects.toThrow(
-                new Error(`getPscIndWithVerificationState - no PSC with verification state returned for companyNumber: ${COMPANY_NUMBER} and PSC notification ID: ${PSC_NOTIFICATION_ID}`));
+            await expect(getPscIndividual(COMPANY_NUMBER, PSC_NOTIFICATION_ID)).rejects.toThrow(
+                new Error(`getPscIndividual - no PSC with verification state returned for companyNumber: ${COMPANY_NUMBER} and PSC notification ID: ${PSC_NOTIFICATION_ID}`));
         });
 
-        it("should throw an Error when no response from API", async () => {
-            mockGetPscIndWithVerificationState.mockResolvedValueOnce(undefined);
+        it("should throw an Error when there is no response", async () => {
+            mockGetPscIndividual.mockResolvedValueOnce(undefined);
 
-            await expect(getPscIndWithVerificationState(COMPANY_NUMBER, PSC_NOTIFICATION_ID)).rejects.toThrow(
-                new Error(`getPscIndWithVerificationState -  Failed to get PSC with verification state for companyNumber: ${COMPANY_NUMBER} and PSC notification ID: ${PSC_NOTIFICATION_ID}`));
+            await expect(getPscIndividual(COMPANY_NUMBER, PSC_NOTIFICATION_ID)).rejects.toThrow(
+                new Error(`getPscIndividual -  Failed to get PSC with verification state for companyNumber: ${COMPANY_NUMBER} and PSC notification ID: ${PSC_NOTIFICATION_ID}`));
         });
-        it("should throw an Error when API status is unavailable", async () => {
-            const mockGet: Resource<PscIndWithVerificationStateResource> = {
+
+        it("should throw an Error when the API resource is missing", async () => {
+            const mockGet: Resource<PersonWithSignificantControlResource> = {
                 httpStatusCode: HttpStatusCode.ServiceUnavailable
             };
 
-            mockGetPscIndWithVerificationState.mockResolvedValueOnce(mockGet);
+            mockGetPscIndividual.mockResolvedValueOnce(mockGet);
 
-            await expect(getPscIndWithVerificationState(COMPANY_NUMBER, PSC_NOTIFICATION_ID)).rejects.toThrow(
-                new Error(`getPscIndWithVerificationState -  Failed to get PSC with verification state for companyNumber: ${COMPANY_NUMBER} and PSC notification ID: ${PSC_NOTIFICATION_ID}`));
+            await expect(getPscIndividual(COMPANY_NUMBER, PSC_NOTIFICATION_ID)).rejects.toThrow(
+                new Error(`getPscIndividual -  Failed to get PSC with verification state for companyNumber: ${COMPANY_NUMBER} and PSC notification ID: ${PSC_NOTIFICATION_ID}`));
         });
 
     });


### PR DESCRIPTION
The PSC service was updated to retrieve an individual PSC with their verification state. 
Config was updated to reference the CHS_INTERNAL_API_KEY in the API client service.

**Notes**
- A temporary block of code has been added to `individualPscListHandler.ts` which may be used to view the verification state in debug mode when running locally in Docker.
- `package-lock.json` has been temporarily update to reference the `api-sdk-node` changes in [PR #764](https://github.com/companieshouse/api-sdk-node/pull/764), and will be reverted following review


