### PR TITLE
Fix mouse cursor on PSC statement checkbox text

### DIFF
--- a/src/views/router_views/individualStatement/individual-statement.njk
+++ b/src/views/router_views/individualStatement/individual-statement.njk
@@ -14,9 +14,9 @@
 ] | join %}
 
 {% set statementText %}
-<label for="pscIndividualStatement">{{ i18n.individual_statement_part1 }}
+    {{ i18n.individual_statement_part1 }}
     <strong>{{ pscName }}</strong>
-    {{ i18n.individual_statement_part2 }}</label>
+    {{ i18n.individual_statement_part2 }}
 {% endset %}
 
 {% block main_content %}

--- a/test/routers/handlers/individual-statement/individualStatement.int.ts
+++ b/test/routers/handlers/individual-statement/individualStatement.int.ts
@@ -60,7 +60,7 @@ describe("individual statement router/handler integration tests", () => {
             if (lang === "en") {
                 expect($("div#nameAndDateOfBirth").text()).toBe("Sir Forename Middlename Surname (Born April 2000)");
                 // expect emphasis applied to PSC name
-                expect(normalizeWhitespace($("label.govuk-checkboxes__label[for='pscIndividualStatement']").html())).toBe("<label for=\"pscIndividualStatement\">I confirm that <strong>Sir Forename Middlename Surname</strong> has verified their identity in accordance with the Companies Act 2006.</label>");
+                expect(normalizeWhitespace($("label.govuk-checkboxes__label[for='pscIndividualStatement']").html())).toBe("I confirm that <strong>Sir Forename Middlename Surname</strong> has verified their identity in accordance with the Companies Act 2006.");
             }
 
             expect($("input.govuk-checkboxes__input[name=pscIndividualStatement]").prop("checked")).toBe(true);
@@ -85,7 +85,7 @@ describe("individual statement router/handler integration tests", () => {
             if (lang === "en") {
                 expect($("div#nameAndDateOfBirth").text()).toBe("Sir Forename Middlename Surname (Born April 2000)");
                 // expect emphasis applied to PSC name
-                expect(normalizeWhitespace($("label.govuk-checkboxes__label[for='pscIndividualStatement']").html())).toBe("<label for=\"pscIndividualStatement\">I confirm that <strong>Sir Forename Middlename Surname</strong> has verified their identity in accordance with the Companies Act 2006.</label>");
+                expect(normalizeWhitespace($("label.govuk-checkboxes__label[for='pscIndividualStatement']").html())).toBe("I confirm that <strong>Sir Forename Middlename Surname</strong> has verified their identity in accordance with the Companies Act 2006.");
             }
 
             expect($("input.govuk-checkboxes__input[name=pscIndividualStatement]").prop("checked")).toBe(true);


### PR DESCRIPTION
Ticket: https://companieshouse.atlassian.net/browse/IDVA3-1924

Previously, when hovering over the checkbox text, the mouse cursor would appear as if you're selecting text rather than performing a click action.