### PR TITLE
IDVA3-2997 Block transaction-related screens if the transaction is closed

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -2,7 +2,7 @@ import cookieParser from "cookie-parser";
 import express from "express";
 import nunjucks from "nunjucks";
 import path from "path";
-import { CommonDataEventIds, ExternalUrls, servicePathPrefix } from "./constants";
+import { CommonDataEventIds, ExternalUrls, servicePathPrefix, urlWithTransactionIdAndSubmissionId } from "./constants";
 import { logger } from "./lib/logger";
 import { sessionMiddleware } from "./middleware/session";
 import routerDispatch from "./routerDispatch";
@@ -11,6 +11,7 @@ import { csrfProtectionMiddleware } from "./middleware/csrf";
 import csrfErrorHandler from "./middleware/csrfErrorHandler";
 import { pageNotFound } from "./middleware/pageNotFound";
 import { internalServerError } from "./middleware/internalServerError";
+import { blockClosedTransaction } from "./middleware/blockClosedTransaction";
 
 const app = express();
 
@@ -53,6 +54,9 @@ app.use(servicePathPrefix, sessionMiddleware);
 // attach csrf protection to middleware
 app.use(csrfProtectionMiddleware);
 app.use(csrfErrorHandler);
+
+// block transaction-related requests if transaction is closed
+app.use(servicePathPrefix + urlWithTransactionIdAndSubmissionId, blockClosedTransaction);
 
 // serve static files
 app.use(express.static(path.join(__dirname, "./../assets/public")));

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,5 @@
 export const servicePathPrefix = "/persons-with-significant-control-verification";
-const urlWithTransactionIdAndSubmissionId = "/transaction/:transactionId/submission/:submissionId";
+export const urlWithTransactionIdAndSubmissionId = "/transaction/:transactionId/submission/:submissionId";
 
 export enum STOP_TYPE {
     COMPANY_STATUS = "company-status",

--- a/src/lib/errors/httpError.ts
+++ b/src/lib/errors/httpError.ts
@@ -1,0 +1,16 @@
+import { HttpStatusCode } from "axios";
+
+export class HttpError extends Error {
+    public status: number;
+
+    constructor (message: string, status: number | HttpStatusCode) {
+        super(message);
+        this.name = "HttpError";
+        this.status = status;
+
+        // Maintains stack trace for where the error was thrown
+        if (Error.captureStackTrace) {
+            Error.captureStackTrace(this, HttpError);
+        }
+    }
+}

--- a/src/middleware/blockClosedTransaction.ts
+++ b/src/middleware/blockClosedTransaction.ts
@@ -1,0 +1,34 @@
+import { logger } from "../lib/logger";
+import { TransactionStatus, getTransaction } from "../services/transactionService";
+
+/**
+ * Middleware to block requests that contain transaction ID if said transaction is already closed.
+ * Allows requests to the psc-verified screen without blocking.
+ *
+ * @param req - The HTTP request object.
+ * @param res - The HTTP response object.
+ * @param next - The next middleware function in the request-response cycle.
+ */
+export const blockClosedTransaction = (req: any, res: any, next: any) => {
+    const transactionId = req.params.transactionId || req.query.transactionId;
+
+    // Skip the middleware for the psc-verified screen
+    if (req.path.includes("psc-verified")) {
+        return next();
+    }
+
+    getTransaction(req, transactionId)
+        .then(transaction => {
+            if (transaction.status === TransactionStatus.CLOSED) {
+                logger.debug(`${transactionId} - Transaction is closed. Blocking request.`);
+                const err = new Error("Transaction is closed");
+                return next(err);
+            }
+        })
+        .catch(err => {
+            logger.error(`${transactionId} - Error while checking transaction status. ${err}`);
+            return next(err);
+        });
+
+    next();
+};

--- a/src/middleware/blockClosedTransaction.ts
+++ b/src/middleware/blockClosedTransaction.ts
@@ -1,3 +1,5 @@
+import { HttpStatusCode } from "axios";
+import { HttpError } from "../lib/errors/httpError";
 import { logger } from "../lib/logger";
 import { TransactionStatus, getTransaction } from "../services/transactionService";
 
@@ -21,13 +23,14 @@ export const blockClosedTransaction = (req: any, res: any, next: any) => {
         .then(transaction => {
             if (transaction.status === TransactionStatus.CLOSED) {
                 logger.debug(`${transactionId} - Transaction is closed. Blocking request.`);
-                const err = new Error("Transaction is closed");
-                return next(err);
+                const httpError = new HttpError("Transaction is closed", HttpStatusCode.Gone);
+                return next(httpError);
             }
         })
         .catch(err => {
             logger.error(`${transactionId} - Error while checking transaction status. ${err}`);
-            return next(err);
+            const httpError = new HttpError(err, HttpStatusCode.InternalServerError);
+            return next(httpError);
         });
 
     next();

--- a/test/authentication/authenticationCheck.int.ts
+++ b/test/authentication/authenticationCheck.int.ts
@@ -7,6 +7,8 @@ import { HttpStatusCode } from "axios";
 import request from "supertest";
 import { createOAuthApiClient } from "../../src/services/apiClientService";
 import { INDIVIDUAL_VERIFICATION_CREATED } from "../mocks/pscVerification.mock";
+import { getTransaction } from "../../src/services/transactionService";
+import { OPEN_PSC_TRANSACTION } from "../mocks/transaction.mock";
 
 jest.mock(".../../../src/services/companyProfileService");
 jest.mock("../../src/services/apiClientService");
@@ -31,6 +33,10 @@ const mockGet: Resource<PscVerification> = {
 };
 mockCreatePscVerification.mockResolvedValueOnce(mockCreate);
 mockGetPscVerification.mockResolvedValueOnce(mockGet);
+
+jest.mock("../../src/services/transactionService");
+const mockGetTransaction = getTransaction as jest.Mock;
+mockGetTransaction.mockResolvedValue(OPEN_PSC_TRANSACTION);
 
 describe("Authentication checked on all pages except for the start page", () => {
 

--- a/test/middleware/blockClosedTransaction.unit.ts
+++ b/test/middleware/blockClosedTransaction.unit.ts
@@ -1,0 +1,70 @@
+import { blockClosedTransaction } from "../../src/middleware/blockClosedTransaction";
+import { getTransaction } from "../../src/services/transactionService";
+import { HttpError } from "../../src/lib/errors/httpError";
+import httpMocks from "node-mocks-http";
+import { PrefixedUrls } from "../../src/constants";
+import { CLOSED_PSC_TRANSACTION, OPEN_PSC_TRANSACTION, PSC_VERIFICATION_ID, TRANSACTION_ID } from "../mocks/transaction.mock";
+
+jest.mock("../../src/services/transactionService");
+const mockGetTransaction = getTransaction as jest.Mock;
+
+function generateRequest (url: string): any {
+    return httpMocks.createRequest({
+        method: "GET",
+        url,
+        params: {
+            transactionId: TRANSACTION_ID,
+            submissionId: PSC_VERIFICATION_ID
+        },
+        query: {
+            pscType: "individual"
+        }
+    });
+}
+
+describe("blockClosedTransaction middleware", () => {
+    const mockNext = jest.fn();
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("should call next if the transaction is open", async () => {
+        const req = generateRequest(PrefixedUrls.PERSONAL_CODE);
+        const res = httpMocks.createResponse();
+
+        mockGetTransaction.mockResolvedValueOnce(OPEN_PSC_TRANSACTION);
+
+        await blockClosedTransaction(req, res, mockNext);
+
+        expect(mockGetTransaction).toHaveBeenCalledWith(req, TRANSACTION_ID);
+        expect(mockNext).toHaveBeenCalled();
+        expect(mockNext).not.toHaveBeenCalledWith(expect.any(HttpError));
+    });
+
+    it("should return an error if the transaction is closed", async () => {
+        const req = generateRequest(PrefixedUrls.PERSONAL_CODE);
+        const res = httpMocks.createResponse();
+
+        mockGetTransaction.mockResolvedValueOnce(CLOSED_PSC_TRANSACTION);
+
+        await blockClosedTransaction(req, res, mockNext);
+
+        expect(mockGetTransaction).toHaveBeenCalledWith(req, TRANSACTION_ID);
+        expect(mockNext).toHaveBeenCalledWith(expect.any(HttpError));
+        const error = mockNext.mock.lastCall![0];
+        expect(error).toBeInstanceOf(HttpError);
+        expect(error.message).toBe("Transaction is closed");
+        expect(error.status).toBe(410); // HTTP GONE
+    });
+
+    it("should skip the middleware for the psc-verified screen", async () => {
+        const req = generateRequest(PrefixedUrls.PSC_VERIFIED);
+        const res = httpMocks.createResponse();
+
+        await blockClosedTransaction(req, res, mockNext);
+
+        expect(mockGetTransaction).not.toHaveBeenCalled();
+        expect(mockNext).toHaveBeenCalled();
+    });
+});

--- a/test/routers/handlers/individual-statement/individualStatement.int.ts
+++ b/test/routers/handlers/individual-statement/individualStatement.int.ts
@@ -13,6 +13,8 @@ import { getPscVerification, patchPscVerification } from "../../../../src/servic
 import app from "../../../../src/app";
 import { PscVerificationData, VerificationStatementEnum } from "@companieshouse/api-sdk-node/dist/services/psc-verification-link/types";
 import { IncomingMessage } from "http";
+import { getTransaction } from "../../../../src/services/transactionService";
+import { OPEN_PSC_TRANSACTION } from "../../../mocks/transaction.mock";
 
 jest.mock("../../../../src/services/pscVerificationService");
 const mockGetPscVerification = getPscVerification as jest.Mock;
@@ -24,6 +26,10 @@ jest.mock("../../../../src/services/pscService", () => ({
         resource: PSC_INDIVIDUAL
     })
 }));
+
+jest.mock("../../../../src/services/transactionService");
+const mockGetTransaction = getTransaction as jest.Mock;
+mockGetTransaction.mockResolvedValue(OPEN_PSC_TRANSACTION);
 
 describe("individual statement router/handler integration tests", () => {
 

--- a/test/routers/handlers/name-mismatch/nameMismatch.int.ts
+++ b/test/routers/handlers/name-mismatch/nameMismatch.int.ts
@@ -14,6 +14,8 @@ import app from "../../../../src/app";
 import { NameMismatchReasonEnum, PscVerificationData } from "@companieshouse/api-sdk-node/dist/services/psc-verification-link/types";
 import { IncomingMessage } from "http";
 import { getPscIndividual } from "../../../../src/services/pscService";
+import { getTransaction } from "../../../../src/services/transactionService";
+import { OPEN_PSC_TRANSACTION } from "../../../mocks/transaction.mock";
 
 jest.mock("../../../../src/services/pscVerificationService");
 jest.mock("../../../../src/services/pscService");
@@ -21,6 +23,10 @@ jest.mock("../../../../src/services/pscService");
 const mockGetPscVerification = getPscVerification as jest.Mock;
 const mockPatchPscVerification = patchPscVerification as jest.Mock;
 const mockGetPscIndividual = getPscIndividual as jest.Mock;
+
+jest.mock("../../../../src/services/transactionService");
+const mockGetTransaction = getTransaction as jest.Mock;
+mockGetTransaction.mockResolvedValue(OPEN_PSC_TRANSACTION);
 
 describe("name mismatch router/handler integration tests", () => {
 

--- a/test/routers/handlers/personal-code/personalCode.int.ts
+++ b/test/routers/handlers/personal-code/personalCode.int.ts
@@ -14,6 +14,8 @@ import { IncomingMessage } from "http";
 import { getPscIndividual } from "../../../../src/services/pscService";
 import { PrefixedUrls, STOP_TYPE } from "../../../../src/constants";
 import { getLocalesService } from "../../../../src/utils/localise";
+import { getTransaction } from "../../../../src/services/transactionService";
+import { OPEN_PSC_TRANSACTION } from "../../../mocks/transaction.mock";
 
 jest.mock("../../../../src/services/pscVerificationService");
 jest.mock("../../../../src/services/pscService");
@@ -21,6 +23,10 @@ jest.mock("../../../../src/services/pscService");
 const mockGetPscVerification = getPscVerification as jest.Mock;
 const mockPatchPscVerification = patchPscVerification as jest.Mock;
 const mockGetPscIndividual = getPscIndividual as jest.Mock;
+
+jest.mock("../../../../src/services/transactionService");
+const mockGetTransaction = getTransaction as jest.Mock;
+mockGetTransaction.mockResolvedValue(OPEN_PSC_TRANSACTION);
 
 describe("personal code router/handler integration tests", () => {
     beforeAll(() => {

--- a/test/routers/handlers/stop-screen/stopScreen.int.ts
+++ b/test/routers/handlers/stop-screen/stopScreen.int.ts
@@ -7,7 +7,7 @@ import mockCsrfProtectionMiddleware from "../../../mocks/csrfProtectionMiddlewar
 import app from "../../../../src/app";
 import { PrefixedUrls, STOP_TYPE, toStopScreenPrefixedUrl } from "../../../../src/constants";
 import { getCompanyProfile } from "../../../../src/services/companyProfileService";
-import { closeTransaction } from "../../../../src/services/transactionService";
+import { closeTransaction, getTransaction } from "../../../../src/services/transactionService";
 import { PSC_INDIVIDUAL } from "../../../mocks/psc.mock";
 import { INDIVIDUAL_VERIFICATION_FULL, PSC_VERIFICATION_ID, TRANSACTION_ID } from "../../../mocks/pscVerification.mock";
 import { validCompanyProfile } from "../../../mocks/companyProfile.mock";
@@ -15,6 +15,7 @@ import { getUrlWithStopType, getUrlWithTransactionIdAndSubmissionId } from "../.
 import { getPscVerification } from "../../../../src/services/pscVerificationService";
 import { getPscIndividual } from "../../../../src/services/pscService";
 import { env } from "../../../../src/config";
+import { OPEN_PSC_TRANSACTION } from "../../../mocks/transaction.mock";
 
 jest.mock("../../../../src/services/pscVerificationService");
 const mockGetPscVerification = getPscVerification as jest.Mock;
@@ -34,11 +35,11 @@ jest.mock("../../../../src/services/companyProfileService");
 const mockGetCompanyProfile = getCompanyProfile as jest.Mock;
 mockGetCompanyProfile.mockResolvedValue(validCompanyProfile);
 
-jest.mock("../../../../src/services/transactionService", () => ({
-    closeTransaction: jest.fn()
-}));
+jest.mock("../../../../src/services/transactionService");
 const mockCloseTransaction = closeTransaction as jest.Mock;
+const mockGetTransaction = getTransaction as jest.Mock;
 mockCloseTransaction.mockResolvedValue({});
+mockGetTransaction.mockResolvedValue(OPEN_PSC_TRANSACTION);
 
 describe("stop screen view tests", () => {
 

--- a/test/routers/individualStatementRouter.int.ts
+++ b/test/routers/individualStatementRouter.int.ts
@@ -5,6 +5,8 @@ import { INDIVIDUAL_VERIFICATION_CREATED } from "../mocks/pscVerification.mock";
 import middlewareMocks from "../mocks/allMiddleware.mock";
 import app from "../../src/app";
 import { PSC_INDIVIDUAL } from "../mocks/psc.mock";
+import { getTransaction } from "../../src/services/transactionService";
+import { OPEN_PSC_TRANSACTION } from "../mocks/transaction.mock";
 
 jest.mock("../../src/services/pscVerificationService", () => ({
     getPscVerification: () => ({
@@ -18,6 +20,9 @@ jest.mock("../../src/services/pscService", () => ({
         resource: PSC_INDIVIDUAL
     })
 }));
+jest.mock("../../src/services/transactionService");
+const mockGetTransaction = getTransaction as jest.Mock;
+mockGetTransaction.mockResolvedValue(OPEN_PSC_TRANSACTION);
 
 beforeEach(() => {
     jest.clearAllMocks();

--- a/test/routers/stopScreenRouter.int.ts
+++ b/test/routers/stopScreenRouter.int.ts
@@ -4,6 +4,12 @@ import { STOP_TYPE, toStopScreenPrefixedUrl } from "../../src/constants";
 import middlewareMocks from "../mocks/allMiddleware.mock";
 import app from "../../src/app";
 import { getUrlWithStopType } from "../../src/utils/url";
+import { getTransaction } from "../../src/services/transactionService";
+import { OPEN_PSC_TRANSACTION } from "../mocks/transaction.mock";
+
+jest.mock("../../src/services/transactionService");
+const mockGetTransaction = getTransaction as jest.Mock;
+mockGetTransaction.mockResolvedValue(OPEN_PSC_TRANSACTION);
 
 beforeEach(() => {
     jest.clearAllMocks();


### PR DESCRIPTION
Jira ticket: https://companieshouse.atlassian.net/browse/IDVA3-2997

Notes:
* Ensure that the PSC you're testing with is able to verify (i.e. no validation errors), otherwise the transaction won't close when you reach the `psc-verified` screen.
* Quite a few tests had to be tweaked to mock an open transaction so that tests don't get blocked when trying to access transaction-related screens. All these tests can be seen in [this commit](https://github.com/companieshouse/psc-verification-web/pull/234/commits/0dac735c04a3958ef7deefacbdaa1bb3ebfb7dbc).

Testing involves going through the journey, making duplicates of each tab as you progress until you get to `psc-verified`, then going back to each screen and refreshing. Any transaction related screens (`personal-code`, `individual-statement`) should present the user with an error, any non-transaction screens should be fine. Note that there's an exception for the `psc-verified` screen, which should refresh fine without presenting an error to the user.