### PR TITLE
IDVA3-2858 Handle data integrity validation errors

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -13,6 +13,7 @@ import { blockClosedTransaction } from "./middleware/blockClosedTransaction";
 import { httpErrorInterceptor } from "./middleware/error-interceptors/httpErrorInterceptor";
 import { HttpError } from "./lib/errors/httpError";
 import { HttpStatusCode } from "axios";
+import { dataIntegrityErrorInterceptor } from "./middleware/error-interceptors/dataIntegrityErrorInterceptor";
 
 const app = express();
 
@@ -84,6 +85,8 @@ routerDispatch(app);
 app.use((req: any, _) => {
     throw new HttpError(`Page not found: ${req.url}`, HttpStatusCode.NotFound);
 });
+
+app.use(dataIntegrityErrorInterceptor);
 
 // intercept HTTP errors
 app.use(httpErrorInterceptor);

--- a/src/lib/errors/dataIntegrityError.ts
+++ b/src/lib/errors/dataIntegrityError.ts
@@ -1,0 +1,19 @@
+
+export enum DataIntegrityErrorType {
+    PSC_DATA = "PSC_DATA",
+}
+
+export class DataIntegrityError extends Error {
+    public type: DataIntegrityErrorType;
+
+    constructor (message: string, type: DataIntegrityErrorType) {
+        super(message);
+        this.name = "DataIntegrityError";
+        this.type = type;
+
+        // Maintains stack trace for where the error was thrown
+        if (Error.captureStackTrace) {
+            Error.captureStackTrace(this, DataIntegrityError);
+        }
+    }
+}

--- a/src/middleware/error-interceptors/dataIntegrityErrorInterceptor.ts
+++ b/src/middleware/error-interceptors/dataIntegrityErrorInterceptor.ts
@@ -11,13 +11,11 @@ export function dataIntegrityErrorInterceptor (err: Error | DataIntegrityError, 
     }
     logger.error(`${err.name} (${err.type}): ${err.stack}`);
 
-    switch (err.type) {
-        case DataIntegrityErrorType.PSC_DATA:
-            res.status(HttpStatusCode.InternalServerError);
-            res.redirect(getUrlWithStopType(PrefixedUrls.STOP_SCREEN, STOP_TYPE.PROBLEM_WITH_PSC_DATA));
-            break;
-        default:
-            return next(new Error(`Unhandled DataIntegrityError type: ${err.type}`));
+    if (err.type === DataIntegrityErrorType.PSC_DATA) {
+        res.status(HttpStatusCode.InternalServerError);
+        res.redirect(getUrlWithStopType(PrefixedUrls.STOP_SCREEN, STOP_TYPE.PROBLEM_WITH_PSC_DATA));
+    } else {
+        return next(new Error(`Unhandled DataIntegrityError type: ${err.type}`));
     }
 
     return next();

--- a/src/middleware/error-interceptors/dataIntegrityErrorInterceptor.ts
+++ b/src/middleware/error-interceptors/dataIntegrityErrorInterceptor.ts
@@ -1,0 +1,24 @@
+import { NextFunction, Request, Response } from "express";
+import { DataIntegrityError, DataIntegrityErrorType } from "../../lib/errors/dataIntegrityError";
+import { HttpStatusCode } from "axios";
+import { PrefixedUrls, STOP_TYPE } from "../../constants";
+import { logger } from "../../lib/logger";
+import { getUrlWithStopType } from "../../utils/url";
+
+export function dataIntegrityErrorInterceptor (err: Error | DataIntegrityError, req: Request, res: Response, next: NextFunction): void {
+    if (!(err instanceof DataIntegrityError)) {
+        return next(err);
+    }
+    logger.error(`${err.name} (${err.type}): ${err.stack}`);
+
+    switch (err.type) {
+        case DataIntegrityErrorType.PSC_DATA:
+            res.status(HttpStatusCode.InternalServerError);
+            res.redirect(getUrlWithStopType(PrefixedUrls.STOP_SCREEN, STOP_TYPE.PROBLEM_WITH_PSC_DATA));
+            break;
+        default:
+            return next(new Error(`Unhandled DataIntegrityError type: ${err.type}`));
+    }
+
+    return next();
+}

--- a/src/routers/handlers/generic.ts
+++ b/src/routers/handlers/generic.ts
@@ -4,7 +4,6 @@
 import { Request, Response } from "express";
 import { ExternalUrls, PrefixedUrls, servicePathPrefix } from "../../constants";
 import errorManifest from "../../lib/utils/error-manifests/errorManifest";
-import { createAndLogError } from "../../lib/logger";
 
 export interface BaseViewData {
     errors: any
@@ -45,7 +44,7 @@ export abstract class GenericHandler<T extends BaseViewData> {
             return err.stack;
         }
 
-        throw createAndLogError(this.errorManifest.generic.serverError.summary);
+        throw err;
     }
 
     populateViewData (req: Request, res: Response) {

--- a/src/routers/handlers/stop-screen/stopScreenHandler.ts
+++ b/src/routers/handlers/stop-screen/stopScreenHandler.ts
@@ -97,7 +97,6 @@ const setContent = async (req: Request, res: Response, stopType: STOP_TYPE, base
                 ...getLocaleInfo(locales, lang),
                 templateName: stopType,
                 currentUrl: addSearchParams(getUrlWithStopType(stopScreenPrefixedUrl, stopType), { companyNumber, lang }),
-                backURL: addSearchParams(PrefixedUrls.INDIVIDUAL_PSC_LIST, { companyNumber, lang }),
                 extraData: [env.ENQUIRIES_EMAIL_ADDRESS, env.ENQUIRIES_PHONE_NUMBER]
             };
         }

--- a/src/services/pscVerificationService.ts
+++ b/src/services/pscVerificationService.ts
@@ -41,8 +41,9 @@ export const createPscVerification = async (request: Request, transaction: Trans
 
     if (!sdkResponse.httpStatusCode) {
         throw new Error(`${createPscVerification.name} - HTTP status code is undefined - Failed to POST PSC Verification for transaction ${transaction.id}`);
-    } else if (sdkResponse.httpStatusCode >= 400 && sdkResponse.httpStatusCode < 500) {
-        throw new DataIntegrityError(`${createPscVerification.name} received ${sdkResponse.httpStatusCode} - Failed to POST PSC Verification for transaction ${transaction.id}`, DataIntegrityErrorType.PSC_DATA);
+    } else if (sdkResponse.httpStatusCode === HttpStatusCode.BadRequest || sdkResponse.httpStatusCode === HttpStatusCode.NotFound) {
+        const message = (sdkResponse as any)?.resource?.errors?.[0]?.error ?? `Failed to POST PSC Verification for transaction ${transaction.id}`;
+        throw new DataIntegrityError(`${createPscVerification.name} received ${sdkResponse.httpStatusCode} - ${message}`, DataIntegrityErrorType.PSC_DATA);
     } else if (sdkResponse.httpStatusCode !== HttpStatusCode.Created) {
         throw new HttpError(`${createPscVerification.name} - Failed to POST PSC Verification for transaction ${transaction.id}`, sdkResponse.httpStatusCode);
     }
@@ -103,8 +104,9 @@ export const patchPscVerification = async (request: Request, transactionId: stri
 
     if (!sdkResponse.httpStatusCode) {
         throw new Error(`${patchPscVerification.name} - HTTP status code is undefined - Failed to PATCH PSC Verification for resource with ${logReference}`);
-    } else if (sdkResponse.httpStatusCode >= 400 && sdkResponse.httpStatusCode < 500) {
-        throw new DataIntegrityError(`${patchPscVerification.name} received ${sdkResponse.httpStatusCode} - Failed to PATCH PSC Verification for resource with ${logReference}`, DataIntegrityErrorType.PSC_DATA);
+    } else if (sdkResponse.httpStatusCode === HttpStatusCode.BadRequest || sdkResponse.httpStatusCode === HttpStatusCode.NotFound) {
+        const message = (sdkResponse as any)?.resource?.errors?.[0]?.error ?? `Failed to PATCH PSC Verification for resource with ${logReference}`;
+        throw new DataIntegrityError(`${patchPscVerification.name} received ${sdkResponse.httpStatusCode} - ${message}`, DataIntegrityErrorType.PSC_DATA);
     } else if (sdkResponse.httpStatusCode !== HttpStatusCode.Ok) {
         throw new HttpError(`${patchPscVerification.name} - Failed to PATCH PSC Verification for resource with ${logReference}`, sdkResponse.httpStatusCode);
     }

--- a/src/services/pscVerificationService.ts
+++ b/src/services/pscVerificationService.ts
@@ -5,10 +5,11 @@ import { ApiErrorResponse, ApiResponse } from "@companieshouse/api-sdk-node/dist
 import { Transaction } from "@companieshouse/api-sdk-node/dist/services/transaction/types";
 import { HttpStatusCode } from "axios";
 import { Request } from "express";
-import { createAndLogError, logger } from "../lib/logger";
+import { logger } from "../lib/logger";
 import { HttpError } from "../lib/errors/httpError";
 import { createApiKeyClient, createOAuthApiClient } from "./apiClientService";
 import { Responses } from "../constants";
+import { DataIntegrityError, DataIntegrityErrorType } from "../lib/errors/dataIntegrityError";
 
 export const createPscVerification = async (request: Request, transaction: Transaction, pscVerification: PscVerificationData): Promise<Resource<PscVerification> | ApiErrorResponse> => {
     if (!pscVerification) {
@@ -18,7 +19,7 @@ export const createPscVerification = async (request: Request, transaction: Trans
         throw new Error(`createPscVerification - Aborting: companyNumber is required for PSC Verification POST request for transaction ${transaction.id}.`);
     }
     if (pscVerification.pscNotificationId == null) {
-        throw createAndLogError(`${createPscVerification.name} - Aborting: pscNotificationId is required for PSC Verification POST request for transaction ${transaction.id}. Has the user tried to resume a journey after signing out and in again?`);
+        throw new Error(`${createPscVerification.name} - Aborting: pscNotificationId is required for PSC Verification POST request for transaction ${transaction.id}. Has the user tried to resume a journey after signing out and in again?`);
     }
 
     const oAuthApiClient: ApiClient = createOAuthApiClient(request.session);
@@ -27,25 +28,29 @@ export const createPscVerification = async (request: Request, transaction: Trans
     const sdkResponse: Resource<PscVerification> | ApiErrorResponse = await oAuthApiClient.pscVerificationService.postPscVerification(transaction.id as string, pscVerification);
 
     if (!sdkResponse) {
-        throw createAndLogError(`${createPscVerification.name} - PSC Verification POST request returned no response for transaction ${transaction.id}`);
+        throw new Error(`${createPscVerification.name} - PSC Verification POST request returned no response for transaction ${transaction.id}`);
     }
 
     if (sdkResponse.httpStatusCode === HttpStatusCode.InternalServerError) {
         const error = ((sdkResponse as ApiErrorResponse).errors?.[0] as ApiErrorResponse).errors?.[0].errorValues?.error as string;
 
         if (RegExp(Responses.PROBLEM_WITH_PSC_DATA as string).exec(error)) {
-            return sdkResponse;
+            throw new DataIntegrityError(`${createPscVerification.name} - ${Responses.PROBLEM_WITH_PSC_DATA} - Failed to POST PSC Verification for transaction ${transaction.id}`, DataIntegrityErrorType.PSC_DATA);
         }
     }
 
-    if (!sdkResponse.httpStatusCode || sdkResponse.httpStatusCode !== HttpStatusCode.Created) {
-        throw createAndLogError(`${createPscVerification.name} - HTTP status code ${sdkResponse.httpStatusCode} - Failed to POST PSC Verification for transaction ${transaction.id}`);
+    if (!sdkResponse.httpStatusCode) {
+        throw new Error(`${createPscVerification.name} - HTTP status code is undefined - Failed to POST PSC Verification for transaction ${transaction.id}`);
+    } else if (sdkResponse.httpStatusCode >= 400 && sdkResponse.httpStatusCode < 500) {
+        throw new DataIntegrityError(`${createPscVerification.name} - ${sdkResponse.httpStatusCode} Failed to POST PSC Verification for transaction ${transaction.id}`, DataIntegrityErrorType.PSC_DATA);
+    } else if (sdkResponse.httpStatusCode !== HttpStatusCode.Created) {
+        throw new HttpError(`${createPscVerification.name} - Failed to POST PSC Verification for transaction ${transaction.id}`, sdkResponse.httpStatusCode);
     }
 
     const castedSdkResponse = sdkResponse as Resource<PscVerification>;
 
     if (!castedSdkResponse.resource) {
-        throw createAndLogError(`${createPscVerification.name} - PSC Verification API POST request returned no resource for transaction ${transaction.id}`);
+        throw new Error(`${createPscVerification.name} - PSC Verification API POST request returned no resource for transaction ${transaction.id}`);
     }
     logger.debug(`${createPscVerification.name} - POST PSC Verification response: ${JSON.stringify(sdkResponse)}`);
 
@@ -60,7 +65,7 @@ export const getPscVerification = async (request: Request, transactionId: string
     const sdkResponse: Resource<PscVerification> | ApiErrorResponse = await oAuthApiClient.pscVerificationService.getPscVerification(transactionId, pscVerificationId);
 
     if (!sdkResponse) {
-        throw createAndLogError(`${getPscVerification.name} - PSC Verification GET request returned no response for ${logReference}`);
+        throw new Error(`${getPscVerification.name} - PSC Verification GET request returned no response for ${logReference}`);
     }
     switch (sdkResponse.httpStatusCode) {
         case HttpStatusCode.Ok:
@@ -78,7 +83,7 @@ export const getPscVerification = async (request: Request, transactionId: string
     const castedSdkResponse = sdkResponse as Resource<PscVerification>;
 
     if (!castedSdkResponse.resource) {
-        throw createAndLogError(`${getPscVerification.name} - PSC Verification API GET request returned no resource for ${logReference}`);
+        throw new Error(`${getPscVerification.name} - PSC Verification API GET request returned no resource for ${logReference}`);
     }
     logger.debug(`${getPscVerification.name} - GET PSC Verification response: ${sdkResponse.httpStatusCode}`);
 
@@ -93,17 +98,21 @@ export const patchPscVerification = async (request: Request, transactionId: stri
     const sdkResponse: Resource<PscVerification> | ApiErrorResponse = await oAuthApiClient.pscVerificationService.patchPscVerification(transactionId, pscVerificationId, pscVerification);
 
     if (!sdkResponse) {
-        throw createAndLogError(`${patchPscVerification.name} - PSC Verification PATCH request returned no response for resource with ${logReference}`);
+        throw new Error(`${patchPscVerification.name} - PSC Verification PATCH request returned no response for resource with ${logReference}`);
     }
 
-    if (!sdkResponse.httpStatusCode || sdkResponse.httpStatusCode !== HttpStatusCode.Ok) {
-        throw createAndLogError(`${patchPscVerification.name} - Http status code ${sdkResponse.httpStatusCode} - Failed to PATCH PSC Verification for resource with ${logReference}`);
+    if (!sdkResponse.httpStatusCode) {
+        throw new Error(`${patchPscVerification.name} - HTTP status code is undefined - Failed to PATCH PSC Verification for resource with ${logReference}`);
+    } else if (sdkResponse.httpStatusCode >= 400 && sdkResponse.httpStatusCode < 500) {
+        throw new DataIntegrityError(`${patchPscVerification.name} received ${sdkResponse.httpStatusCode} - Failed to PATCH PSC Verification for resource with ${logReference}`, DataIntegrityErrorType.PSC_DATA);
+    } else if (sdkResponse.httpStatusCode !== HttpStatusCode.Ok) {
+        throw new HttpError(`${patchPscVerification.name} - Failed to PATCH PSC Verification for resource with ${logReference}`, sdkResponse.httpStatusCode);
     }
 
     const castedSdkResponse = sdkResponse as Resource<PscVerification>;
 
     if (!castedSdkResponse.resource) {
-        throw createAndLogError(`PSC Verification API PATCH request returned no resource with ${logReference}`);
+        throw new Error(`PSC Verification API PATCH request returned no resource with ${logReference}`);
     }
     logger.debug(`${patchPscVerification.name} - PATCH HTTP status code response for ${logReference}: ${sdkResponse.httpStatusCode}`);
     logger.debug(`${patchPscVerification.name} - PATCH PSC Verification response for ${logReference}: ${JSON.stringify(sdkResponse)}`);
@@ -118,10 +127,10 @@ export const checkPlannedMaintenance = async (request: Request): Promise<ApiResp
     const sdkResponse: ApiResponse<PlannedMaintenance> | ApiErrorResponse = await apiClient.pscVerificationService.checkPlannedMaintenance();
 
     if (!sdkResponse) {
-        throw createAndLogError(`${checkPlannedMaintenance.name} - PSC Verification GET maintenance request returned no response`);
+        throw new Error(`${checkPlannedMaintenance.name} - PSC Verification GET maintenance request returned no response`);
     }
     if (!sdkResponse.httpStatusCode || sdkResponse.httpStatusCode !== HttpStatusCode.Ok) {
-        throw createAndLogError(`${checkPlannedMaintenance.name} - HTTP status code ${sdkResponse.httpStatusCode} - Failed to GET Planned Maintenance response`);
+        throw new Error(`${checkPlannedMaintenance.name} - HTTP status code ${sdkResponse.httpStatusCode} - Failed to GET Planned Maintenance response`);
     }
 
     const castedSdkResponse = sdkResponse as ApiResponse<PlannedMaintenance>;
@@ -138,11 +147,11 @@ export const getValidationStatus = async (request: Request, transactionId: strin
     const sdkResponse: Resource<ValidationStatusResponse> | ApiErrorResponse = await oAuthApiClient.pscVerificationService.getValidationStatus(transactionId, pscVerificationId);
 
     if (!sdkResponse) {
-        throw createAndLogError(`${getValidationStatus.name} - PSC Verification GET validation status request did not return a response for ${logReference}`);
+        throw new Error(`${getValidationStatus.name} - PSC Verification GET validation status request did not return a response for ${logReference}`);
     }
 
     if (sdkResponse.httpStatusCode !== HttpStatusCode.Ok) {
-        throw createAndLogError(`${getValidationStatus.name} - Error getting validation status: HTTP response is: ${sdkResponse.httpStatusCode} for ${logReference}`);
+        throw new Error(`${getValidationStatus.name} - Error getting validation status: HTTP response is: ${sdkResponse.httpStatusCode} for ${logReference}`);
     }
 
     const validationStatus = sdkResponse as Resource<ValidationStatusResponse>;
@@ -150,7 +159,7 @@ export const getValidationStatus = async (request: Request, transactionId: strin
     if (validationStatus.resource?.isValid === false) {
         logger.error(`Validation errors for resource ${logReference}: ` + JSON.stringify(validationStatus.resource.errors.slice(0, 10)));
     } else if (validationStatus.resource?.isValid === undefined) {
-        throw createAndLogError(`${getValidationStatus.name} - Error getting validation status for ${logReference}`);
+        throw new Error(`${getValidationStatus.name} - Error getting validation status for ${logReference}`);
     }
 
     return validationStatus;

--- a/src/services/pscVerificationService.ts
+++ b/src/services/pscVerificationService.ts
@@ -13,13 +13,13 @@ import { DataIntegrityError, DataIntegrityErrorType } from "../lib/errors/dataIn
 
 export const createPscVerification = async (request: Request, transaction: Transaction, pscVerification: PscVerificationData): Promise<Resource<PscVerification> | ApiErrorResponse> => {
     if (!pscVerification) {
-        throw new Error(`getPscVerification - Aborting: PscVerificationData is required for PSC Verification POST request for transaction ${transaction.id}`);
+        throw new Error(`${createPscVerification.name} - Aborting: PscVerificationData is required for PSC Verification POST request for transaction ${transaction.id}`);
     }
     if (!pscVerification.companyNumber) {
-        throw new Error(`createPscVerification - Aborting: companyNumber is required for PSC Verification POST request for transaction ${transaction.id}.`);
+        throw new Error(`${createPscVerification.name} - Aborting: companyNumber is required for PSC Verification POST request for transaction ${transaction.id}.`);
     }
     if (pscVerification.pscNotificationId == null) {
-        throw new Error(`${createPscVerification.name} - Aborting: pscNotificationId is required for PSC Verification POST request for transaction ${transaction.id}. Has the user tried to resume a journey after signing out and in again?`);
+        throw new DataIntegrityError(`${createPscVerification.name} - Aborting: pscNotificationId is required for PSC Verification POST request for transaction ${transaction.id}.`, DataIntegrityErrorType.PSC_DATA);
     }
 
     const oAuthApiClient: ApiClient = createOAuthApiClient(request.session);
@@ -42,7 +42,7 @@ export const createPscVerification = async (request: Request, transaction: Trans
     if (!sdkResponse.httpStatusCode) {
         throw new Error(`${createPscVerification.name} - HTTP status code is undefined - Failed to POST PSC Verification for transaction ${transaction.id}`);
     } else if (sdkResponse.httpStatusCode >= 400 && sdkResponse.httpStatusCode < 500) {
-        throw new DataIntegrityError(`${createPscVerification.name} - ${sdkResponse.httpStatusCode} Failed to POST PSC Verification for transaction ${transaction.id}`, DataIntegrityErrorType.PSC_DATA);
+        throw new DataIntegrityError(`${createPscVerification.name} received ${sdkResponse.httpStatusCode} - Failed to POST PSC Verification for transaction ${transaction.id}`, DataIntegrityErrorType.PSC_DATA);
     } else if (sdkResponse.httpStatusCode !== HttpStatusCode.Created) {
         throw new HttpError(`${createPscVerification.name} - Failed to POST PSC Verification for transaction ${transaction.id}`, sdkResponse.httpStatusCode);
     }

--- a/test/middleware/error-interceptors/dataIntegrityErrorInterceptor.unit.ts
+++ b/test/middleware/error-interceptors/dataIntegrityErrorInterceptor.unit.ts
@@ -1,0 +1,50 @@
+import { NextFunction, Request, Response } from "express";
+import { DataIntegrityError, DataIntegrityErrorType } from "../../../src/lib/errors/dataIntegrityError";
+import { dataIntegrityErrorInterceptor } from "../../../src/middleware/error-interceptors/dataIntegrityErrorInterceptor";
+import { logger } from "../../../src/lib/logger";
+import { HttpStatusCode } from "axios";
+
+jest.mock("../../../src/lib/logger");
+
+describe("dataIntegrityErrorInterceptor", () => {
+    let req: Partial<Request>;
+    let res: Partial<Response>;
+    let next: jest.MockedFunction<NextFunction>;
+
+    beforeEach(() => {
+        req = {};
+        res = {
+            status: jest.fn().mockReturnThis(),
+            redirect: jest.fn()
+        };
+        next = jest.fn();
+        jest.clearAllMocks();
+    });
+
+    it("should pass non-DataIntegrityError errors to the next middleware", () => {
+        const error = new Error("Some other error");
+
+        dataIntegrityErrorInterceptor(error, req as Request, res as Response, next);
+
+        expect(next).toHaveBeenCalledWith(error);
+    });
+
+    it("should log the error and redirect for PSC_DATA type", () => {
+        const error = new DataIntegrityError("PSC data issue", DataIntegrityErrorType.PSC_DATA);
+
+        dataIntegrityErrorInterceptor(error, req as Request, res as Response, next);
+
+        expect(logger.error).toHaveBeenCalledWith(`${error.name} (${error.type}): ${error.stack}`);
+        expect(res.status).toHaveBeenCalledWith(HttpStatusCode.InternalServerError);
+        expect(res.redirect).toHaveBeenCalledWith("/persons-with-significant-control-verification/stop/problem-with-psc-data");
+        expect(next).toHaveBeenCalled();
+    });
+
+    it("should pass unhandled DataIntegrityError types to the next middleware as a generic error", () => {
+        const error = new DataIntegrityError("Unhandled type", "UNHANDLED_TYPE" as DataIntegrityErrorType);
+
+        dataIntegrityErrorInterceptor(error, req as Request, res as Response, next);
+
+        expect(next).toHaveBeenCalledWith(new Error(`Unhandled DataIntegrityError type: ${error.type}`));
+    });
+});

--- a/test/routers/handlers/stop-screen/stopScreen.int.ts
+++ b/test/routers/handlers/stop-screen/stopScreen.int.ts
@@ -100,7 +100,6 @@ describe("stop screen view tests", () => {
                 expect($("a#mail-to-dsr").attr("href")).toBe(`mailto:${env.DSR_EMAIL_ADDRESS}`);
                 break;
             case STOP_TYPE.PROBLEM_WITH_PSC_DATA:
-                expect($("a.govuk-back-link").attr("href")).toBe(`${PrefixedUrls.INDIVIDUAL_PSC_LIST}?companyNumber=00006400&lang=en`);
                 expect($("p.govuk-body").text()).toContain("You'll need to call or email Companies House to resolve it before you can provide verification details. You'll be asked to provide the company number.");
                 break;
             default:

--- a/test/routers/handlers/stop-screen/stopScreenHandler.unit.ts
+++ b/test/routers/handlers/stop-screen/stopScreenHandler.unit.ts
@@ -117,8 +117,7 @@ describe("Stop screen handler", () => {
                 case STOP_TYPE.PROBLEM_WITH_PSC_DATA:
                     expect(viewData).toMatchObject({
                         ...expectedViewData,
-                        currentUrl: `/persons-with-significant-control-verification/stop/${stopType}?companyNumber=00006400&lang=en`,
-                        backURL: `${PrefixedUrls.INDIVIDUAL_PSC_LIST}?companyNumber=00006400&lang=en`
+                        currentUrl: `/persons-with-significant-control-verification/stop/${stopType}?companyNumber=00006400&lang=en`
                     });
                     break;
                 default:

--- a/test/services/pscVerificationService.unit.ts
+++ b/test/services/pscVerificationService.unit.ts
@@ -122,21 +122,7 @@ describe("pscVerificationService", () => {
             expect(response).toBeUndefined();
         });
 
-        it("should throw a HttpError when API status is anything other than 200 ok / 4XX", async () => {
-            const mockCreate: Resource<PscVerification> = {
-                httpStatusCode: HttpStatusCode.ServiceUnavailable
-            };
-            mockCreatePscVerification.mockResolvedValueOnce(mockCreate);
-
-            const response = await createPscVerification(req, CREATED_PSC_TRANSACTION, INITIAL_PSC_DATA).catch((error) => {
-                expect(error).toBeInstanceOf(HttpError);
-                expect(error).toHaveProperty("status", HttpStatusCode.ServiceUnavailable);
-                expect(error).toHaveProperty("message", `createPscVerification - Failed to POST PSC Verification for transaction ${TRANSACTION_ID}`);
-            });
-            expect(response).toBeUndefined();
-        });
-
-        it.each([400, 499])("should throw a DataIntegrityError when API status is a client error (4XX)", async (status) => {
+        it.each([400, 404])("should throw a DataIntegrityError when API status is 400/404", async (status) => {
             const mockCreate: Resource<PscVerification> = {
                 httpStatusCode: status
             };
@@ -146,6 +132,40 @@ describe("pscVerificationService", () => {
                 expect(error).toBeInstanceOf(DataIntegrityError);
                 expect(error).toHaveProperty("type", "PSC_DATA");
                 expect(error).toHaveProperty("message", `createPscVerification received ${status} - Failed to POST PSC Verification for transaction ${TRANSACTION_ID}`);
+            });
+            expect(response).toBeUndefined();
+        });
+
+        it.each([400, 404])("should parse API error response text when available & API status is 400/404", async (status) => {
+            const errorMessage = "Error message";
+            const mockCreate = {
+                httpStatusCode: status,
+                resource: {
+                    errors: [{
+                        error: errorMessage
+                    }]
+                }
+            };
+            mockCreatePscVerification.mockResolvedValueOnce(mockCreate);
+
+            const response = await createPscVerification(req, CREATED_PSC_TRANSACTION, INITIAL_PSC_DATA).catch((error) => {
+                expect(error).toBeInstanceOf(DataIntegrityError);
+                expect(error).toHaveProperty("type", "PSC_DATA");
+                expect(error).toHaveProperty("message", `createPscVerification received ${status} - ${errorMessage}`);
+            });
+            expect(response).toBeUndefined();
+        });
+
+        it("should throw a HttpError when an unsuccessful API status is otherwise unhandled", async () => {
+            const mockCreate: Resource<PscVerification> = {
+                httpStatusCode: HttpStatusCode.ServiceUnavailable
+            };
+            mockCreatePscVerification.mockResolvedValueOnce(mockCreate);
+
+            const response = await createPscVerification(req, CREATED_PSC_TRANSACTION, INITIAL_PSC_DATA).catch((error) => {
+                expect(error).toBeInstanceOf(HttpError);
+                expect(error).toHaveProperty("status", HttpStatusCode.ServiceUnavailable);
+                expect(error).toHaveProperty("message", `createPscVerification - Failed to POST PSC Verification for transaction ${TRANSACTION_ID}`);
             });
             expect(response).toBeUndefined();
         });
@@ -305,21 +325,7 @@ describe("pscVerificationService", () => {
             expect(response).toBeUndefined();
         });
 
-        it("should throw a HttpError when API status is anything other than 200 ok / 4XX", async () => {
-            const mockPatch: Resource<PscVerification> = {
-                httpStatusCode: HttpStatusCode.ServiceUnavailable
-            };
-            mockPatchPscVerification.mockResolvedValueOnce(mockPatch);
-
-            const response = await patchPscVerification(req, TRANSACTION_ID, PSC_VERIFICATION_ID, PATCH_INDIVIDUAL_DATA).catch((error) => {
-                expect(error).toBeInstanceOf(HttpError);
-                expect(error).toHaveProperty("status", HttpStatusCode.ServiceUnavailable);
-                expect(error).toHaveProperty("message", `patchPscVerification - Failed to PATCH PSC Verification for resource with transactionId ${TRANSACTION_ID}, pscVerificationId ${PSC_VERIFICATION_ID}`);
-            });
-            expect(response).toBeUndefined();
-        });
-
-        it.each([400, 499])("should throw a DataIntegrityError when API status is a client error (4XX)", async (status) => {
+        it.each([400, 404])("should throw a DataIntegrityError when API status is 400/404", async (status) => {
             const mockPatch: Resource<PscVerification> = {
                 httpStatusCode: status
             };
@@ -329,6 +335,40 @@ describe("pscVerificationService", () => {
                 expect(error).toBeInstanceOf(DataIntegrityError);
                 expect(error).toHaveProperty("type", "PSC_DATA");
                 expect(error).toHaveProperty("message", `patchPscVerification received ${status} - Failed to PATCH PSC Verification for resource with transactionId ${TRANSACTION_ID}, pscVerificationId ${PSC_VERIFICATION_ID}`);
+            });
+            expect(response).toBeUndefined();
+        });
+
+        it.each([400, 404])("should parse API error response text when available & API status is 400/404", async (status) => {
+            const errorMessage = "Error message";
+            const mockPatch = {
+                httpStatusCode: status,
+                resource: {
+                    errors: [{
+                        error: errorMessage
+                    }]
+                }
+            };
+            mockPatchPscVerification.mockResolvedValueOnce(mockPatch);
+
+            const response = await patchPscVerification(req, TRANSACTION_ID, PSC_VERIFICATION_ID, PATCH_INDIVIDUAL_DATA).catch((error) => {
+                expect(error).toBeInstanceOf(DataIntegrityError);
+                expect(error).toHaveProperty("type", "PSC_DATA");
+                expect(error).toHaveProperty("message", `patchPscVerification received ${status} - ${errorMessage}`);
+            });
+            expect(response).toBeUndefined();
+        });
+
+        it("should throw a HttpError when an unsuccessful API status is otherwise unhandled", async () => {
+            const mockPatch: Resource<PscVerification> = {
+                httpStatusCode: HttpStatusCode.ServiceUnavailable
+            };
+            mockPatchPscVerification.mockResolvedValueOnce(mockPatch);
+
+            const response = await patchPscVerification(req, TRANSACTION_ID, PSC_VERIFICATION_ID, PATCH_INDIVIDUAL_DATA).catch((error) => {
+                expect(error).toBeInstanceOf(HttpError);
+                expect(error).toHaveProperty("status", HttpStatusCode.ServiceUnavailable);
+                expect(error).toHaveProperty("message", `patchPscVerification - Failed to PATCH PSC Verification for resource with transactionId ${TRANSACTION_ID}, pscVerificationId ${PSC_VERIFICATION_ID}`);
             });
             expect(response).toBeUndefined();
         });


### PR DESCRIPTION
Jira ticket: https://companieshouse.atlassian.net/browse/IDVA3-2858

Notes:

- The `backUrl` was removed from "problem with PSC data" stop screen since the stop screen can now in more than one point along the web journey. 
- The ticket mentions two etag scenarios but I was unable to find any API error response for them in psc-verification-api. After some discussion we decided to remove the two scenarios from the ticket ACs.
- On top of specific error scenarios being handled differently in `pscVerificationService.ts`, I also rewrote every `createAndLogError()` into its basic error equivalent for consistency. Thrown Errors are automatically logged by interceptors now. 