### PR TITLE
IDVA3-3088 Update logging output for production readiness

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,7 @@
+
+# Documentation
+
+This directory contains developer docs on the following topics:
+
+* [Logging](./logging.md)
+* [Error Handling](./error-handling.md)

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -1,0 +1,3 @@
+
+# Error Handling
+

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,118 @@
+
+# Logging
+
+Logging is handled in a few key ways in psc-verification-web:
+
+1. Automatic logging via external middleware like `sessionMiddleware`.
+2. Implicit logging via thrown Errors.
+3. Explicit logging via [ch-structured-logging-node](https://github.com/companieshouse/ch-structured-logging-node).
+
+This document refers to methods 2 and 3.
+
+## Logging format
+
+### Format
+The format we use for logging is as follows:
+
+```log
+{date}: {log-level}: {class-name}::{method-name} - {message}
+  -> {context}
+```
+
+Context is typically useful when utilising functions like `logger.errorRequest` which take extra context from the current Express `Request`.
+
+### Example
+```log
+2025-05-30T13:04:40.996+00:00 info: StartHandler::executeGet - called to serve start page
+  -> created: 2025-05-30T13:04:40.996+00:00
+  -> event: info
+  -> namespace: psc-verification-web
+```
+
+## Usage
+For 99% of log use, the developer only needs to know to call one of the following methods:
+* `logger.error(message)` or `logger.errorRequest(req, message)`
+* `logger.info(message)` or `logger.infoRequest(req, message)`
+* `logger.debug(message)` or `logger.debugRequest(req, message)`
+* `logger.trace(message)` or `logger.traceRequest(req, message)`
+
+Everything else, including the `ClassName::methodName -` prefix, will be automatically inserted. A typical log line may look like:
+
+```ts
+// Fictional example: getCompany() in the CompanyService class
+logger.error(`No response from API for companyNumber="${companyNumber}"`);
+```
+```
+2025-05-30T13:04:40.996+00:00 error: CompanyService::getCompany - No response from API for companyNumber="00006400"
+  -> ...
+```
+
+### Implicit logging via thrown Errors
+Throwing an error implicitly generates a log in a very similar way. For example:
+```ts
+// Fictional example: getPsc() in the PscService class
+throw new HttpError(`PSC not found`, HttpStatusCode.NotFound);
+```
+```
+2025-05-30T13:04:40.996+00:00 error: PscService::getPsc - 404 HttpError: PSC not found
+  stack trace start
+  ...
+  stack trace end
+  -> ...
+```
+2025-05-30T14:31:55.143+00:00 error: StartHandler::executeGet - 501 HttpError: not implemented
+
+### Advanced
+`logger` is actually a custom wrapper (called `PrefixedLogger`) around [ch-structured-logging-node](https://github.com/companieshouse/ch-structured-logging-node)'s `ApplicationLogger`. All it does is prepend the `ClassName::methodName -` prefix to every log line.
+
+This works by creating a dummy `Error` and parsing the stack trace to find the function that called for the logger. The `Error` is only instantiated, not thrown.
+
+Typically this works without any extra steps, however there's a caveat for pieces of code like error interceptors and the logging interceptor where you have to be specific about where you're looking in the stack trace in order to get the correct function call back.
+
+For this reason, `PrefixedLogger` exposes an inner `raw` member which allows access to the underlying `ApplicationLogger`. For example: `logger.raw.debug(...)`. `PrefixedLogger` also has a `getPrefix()` method which can take arguments for targeting specific stack lines. See the examples below.
+
+#### Stack position
+[requestLogger.ts](https://github.com/companieshouse/psc-verification-web/blob/main/src/middleware/requestLogger.ts) is an example of a piece of code where the stack position of the function call we want to log out isn't where it would usually be. 
+
+In the case of `requestLogger`, that's because the prefix cannot be generated within the `res.on("finish")` callback since the callback is handled by Express. Instead, the prefix is pre-generated. Because of this, there's one less function call in between `requestLogger` and `getPrefix`. What would usually be `requestLogger -> logger.debug -> this.getPrefix` is now instead `requestLogger -> logger.getPrefix`.
+
+A fictional example: `logger.getPrefix({ stackPos: 2 })`
+
+```diff
+Error
+  at LoggingInterceptor.handle (/app/src/middleware/loggingInterceptor.ts:42:15)
++ at CompanyService.getCompany (/app/src/services/companyService.ts:88:22)
+  at processTicksAndRejections (node:internal/process/task_queues:96:5)
+```
+Output
+```
+CompanyService::getCompany
+```
+
+#### Usage in error interceptors
+Since error interceptors are already dealing with an `Error`, the default strategy of instantiating a new `Error` won't work since the throwing code is referenced only in the original `Error`. In this case, there's an option to pass it through via: `logger.getPrefix({ error: error })`. See [httpErrorInterceptor.ts](https://github.com/companieshouse/psc-verification-web/blob/main/src/middleware/error-interceptors/httpErrorInterceptor.ts) for a real example.
+
+## Best practices
+
+### Identifiers
+Identifiers should typically be in the format `companyNumber="${...}", transactionId="${...}", ...`. This is a convention that allows us to more easily search for identifiers across services.
+
+> [!NOTE]  
+> Ensure that the double quotes around the ID are present, as it's easy to forget.
+
+### What *not* to log :x:
+
+#### Personal information
+- Full names
+- Addresses
+- Email addresses
+- Phone numbers
+- Any data protected under GDPR or similar
+
+#### Client information
+- IP addresses
+- Authentication credentials like passwords and tokens.
+- Other sensitive client identifiers
+
+#### Other
+- Full request or response bodies containing user-submitted data.

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -60,7 +60,6 @@ throw new HttpError(`PSC not found`, HttpStatusCode.NotFound);
   stack trace end
   -> ...
 ```
-2025-05-30T14:31:55.143+00:00 error: StartHandler::executeGet - 501 HttpError: not implemented
 
 ### Advanced
 `logger` is actually a custom wrapper (called `PrefixedLogger`) around [ch-structured-logging-node](https://github.com/companieshouse/ch-structured-logging-node)'s `ApplicationLogger`. All it does is prepend the `ClassName::methodName -` prefix to every log line.

--- a/src/httpServer.ts
+++ b/src/httpServer.ts
@@ -9,7 +9,7 @@ const httpServer = http.createServer(app);
 httpServer.listen(process.env.NODE_PORT, () => {
     console.log(`Server started at: ${process.env.NODE_HOSTNAME}:${process.env.NODE_PORT}`);
 }).on("error", err => {
-    logger.error(`${err.name} - HTTP Server error: ${err.message} - ${err.stack}`);
+    logger.error(`HTTP Server error: ${err.message} - ${err.stack}`);
 });
 
 // Start the secure server - possibly not required if app is running behind a loadbalancer, with SSL termination
@@ -23,7 +23,7 @@ if (process.env.NODE_SSL_ENABLED === "ON") {
     httpsServer.listen(process.env.NODE_PORT_SSL, () => {
         console.log(`Secure server started at: ${process.env.NODE_HOSTNAME_SECURE}:${process.env.NODE_PORT_SSL}`);
     }).on("error", err => {
-        logger.error(`${err.name} - HTTPS Server error: ${err.message} - ${err.stack}`);
+        logger.error(`HTTPS Server error: ${err.message} - ${err.stack}`);
     });
 }
 

--- a/src/lib/errors/dataIntegrityError.ts
+++ b/src/lib/errors/dataIntegrityError.ts
@@ -8,7 +8,7 @@ export class DataIntegrityError extends Error {
 
     constructor (message: string, type: DataIntegrityErrorType) {
         super(message);
-        this.name = "DataIntegrityError";
+        this.name = `DataIntegrityError (${type})`;
         this.type = type;
 
         // Maintains stack trace for where the error was thrown

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -2,15 +2,105 @@ import { createLogger } from "@companieshouse/structured-logging-node";
 import ApplicationLogger from "@companieshouse/structured-logging-node/lib/ApplicationLogger";
 import { PSC_VERIFICATION_WEB_NAMESPACE } from "./constants";
 import { env } from "../config";
-
-export const logger: ApplicationLogger = createLogger(env.APP_NAME ?? PSC_VERIFICATION_WEB_NAMESPACE);
+import { Request } from "express";
 
 // tslint:disable-next-line:no-console
 console.log(`env.LOG_LEVEL set to ${env.LOG_LEVEL}`);
 
-// TODO: deprecate this in favour of logging in httpErrorInterceptor?
-export const createAndLogError = (description: string): Error => {
-    const error = new Error(description);
-    logger.error(`${error.stack}`);
-    return error;
-};
+export interface LogPrefixOptions {
+    stackPos?: number;
+    error?: Error;
+}
+
+export class PrefixedLogger {
+    readonly raw: ApplicationLogger;
+
+    constructor () {
+        this.raw = createLogger(env.APP_NAME ?? PSC_VERIFICATION_WEB_NAMESPACE);
+    }
+
+    info (message: string) {
+        this.raw.info(`${this.getPrefix()} ${message}`);
+    }
+
+    error (message: string) {
+        this.raw.error(`${this.getPrefix()} ${message}`);
+    }
+
+    debug (message: string) {
+        this.raw.debug(`${this.getPrefix()} ${message}`);
+    }
+
+    trace (message: string) {
+        this.raw.trace(`${this.getPrefix()} ${message}`);
+    }
+
+    infoRequest (req: Request, message: string) {
+        this.raw.infoRequest(req, `${this.getPrefix()} ${message}`);
+    }
+
+    errorRequest (req: Request, message: string) {
+        this.raw.errorRequest(req, `${this.getPrefix()} ${message}`);
+    }
+
+    debugRequest (req: Request, message: string) {
+        this.raw.debugRequest(req, `${this.getPrefix()} ${message}`);
+    }
+
+    traceRequest (req: Request, message: string) {
+        this.raw.traceRequest(req, `${this.getPrefix()} ${message}`);
+    }
+
+    /**
+     * Extracts context from the stack trace to provide a prefix for log messages.
+     *
+     * @returns {string} The prefix for the log context in the format "ClassName::methodName -".
+     */
+    public getPrefix (options: LogPrefixOptions = {}): string {
+        // Default stack position is 3 unless specified:
+        // - 0: the error
+        // - 1: this.getPrefix() call
+        // - 2: PrefixedLogger.getPrefix() call
+        // - 3: The actual method that called for the logger
+        let { stackPos = 3, error } = options;
+
+        // If no error is provided, create a new Error to capture the stack trace
+        if (!error) {
+            error = new Error();
+        } else {
+            stackPos -= 2; // Adjust stack position if an error is provided
+        }
+        const stack = error.stack?.split("\n");
+
+        // If the stack trace is not available or does not have enough lines, log an error and return an empty string
+        if (!stack || stack.length <= stackPos) {
+            this.raw.error(`${this.getPrefix.name} - unable to extract log prefix from stack trace: ${error.stack}`);
+            return "";
+        }
+
+        // There are two possible formats for the stack lines:
+        //  A: class, method, filepath ~ "    at ClassName.methodName (path/to/file.ts:line:col)"
+        //  B: just filepath           ~ "    at /path/to/file.ts:line:col"
+
+        // Format A (class/method)
+        const classMethodRegex = /at\s+(.*)\s+\(/;
+        const classMethodMatch = classMethodRegex.exec(stack[stackPos]);
+        if (classMethodMatch?.[1]) {
+            const prefix = classMethodMatch[1].replace(".", "::");
+            return prefix + " -"; // "ClassName::methodName -"
+        }
+
+        // Format B (filepath)
+        const filePathRegex = /at\s+([^\s]+)/;
+        const filePathMatch = filePathRegex.exec(stack[stackPos]);
+        if (filePathMatch?.[1]) {
+            const prefix = filePathMatch[1].split("/").pop()?.split(".")[0];
+            return prefix + " -"; // "fileName -"
+        }
+
+        this.raw.error(`${this.getPrefix.name} - unable to extract log prefix from stack trace: ${error.stack}`);
+        return "";
+    }
+}
+
+export const logger = new PrefixedLogger();

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -60,7 +60,7 @@ export class PrefixedLogger {
         // Default stack position is 3 unless specified:
         // - 0: the error
         // - 1: this.getPrefix() call
-        // - 2: PrefixedLogger.getPrefix() call
+        // - 2: PrefixedLogger.{debug,error,etc}() call
         // - 3: The actual method that called for the logger
         let { stackPos = 3, error } = options;
 

--- a/src/lib/validation/form-validators/pscVerification.ts
+++ b/src/lib/validation/form-validators/pscVerification.ts
@@ -22,7 +22,7 @@ export class PscVerificationFormsValidator extends GenericValidator {
     }
 
     private validateForm (payload: any, fieldName: string, errorKey: string, pscName: string): Promise<Object> {
-        logger.debug(`${PscVerificationFormsValidator.name} - validating ${errorKey} form for ${pscName}`);
+        logger.debug(`validating ${errorKey} form for ${pscName}`);
         this.errorManifest = errorManifest(this.lang);
 
         try {
@@ -42,7 +42,7 @@ export class PscVerificationFormsValidator extends GenericValidator {
 
     private validateForEmptyField (payload: any, fieldName: string, errorKey: string): void {
         if (typeof payload[fieldName] === "undefined" || payload[fieldName] === "") {
-            logger.info(`${PscVerificationFormsValidator.name} - a required field is either empty or undefined`);
+            logger.debug(`required field '${fieldName}' is either empty or undefined`);
             this.errors.stack[fieldName] = this.errorManifest.validation[errorKey].blank;
         }
     }

--- a/src/middleware/blockClosedTransaction.ts
+++ b/src/middleware/blockClosedTransaction.ts
@@ -1,6 +1,5 @@
 import { HttpStatusCode } from "axios";
 import { HttpError } from "../lib/errors/httpError";
-import { logger } from "../lib/logger";
 import { TransactionStatus, getTransaction } from "../services/transactionService";
 
 /**
@@ -30,10 +29,9 @@ export const blockClosedTransaction = (req: any, res: any, next: any) => {
             }
         } catch (err: unknown) {
             if ((err instanceof HttpError && err.status === HttpStatusCode.Unauthorized)) {
-                return next(new HttpError(`${blockClosedTransaction.name} - User not authorized owner for transaction ${transactionId}`, HttpStatusCode.NotFound));
+                return next(new HttpError(`User not authorized owner for transactionId="${transactionId}"`, HttpStatusCode.NotFound));
             }
-            logger.error(`${transactionId} - Error while checking transaction status. ${err}`);
-            const errorMessage = err instanceof Error ? err.message : "An unknown error occurred";
+            const errorMessage = err instanceof Error ? err.message : `failed to check transaction status for transactionId="${transactionId}"`;
             const httpError = new HttpError(errorMessage, HttpStatusCode.InternalServerError);
             return next(httpError);
         }

--- a/src/middleware/checkCompany.ts
+++ b/src/middleware/checkCompany.ts
@@ -15,10 +15,10 @@ export const checkCompany = (req: Request, res: Response, next: NextFunction) =>
     const companyTypeAllowed: string[] = getPscVerificationCompanyLists(COMPANY_TYPE_ALLOWED);
 
     if (companyStatusNotAllowed.includes(companyProfile.companyStatus)) {
-        logger.debug(`${checkCompany.name} - Company Status ${companyProfile.companyStatus} for company number ${companyNumber} is not allowed`);
+        logger.debug(`Company Status ${companyProfile.companyStatus} for company with companyNumber="${companyNumber}" is not allowed`);
         res.redirect(addSearchParams(getUrlWithStopType(PrefixedUrls.STOP_SCREEN, STOP_TYPE.COMPANY_STATUS), { companyNumber, lang }));
     } else if (!companyTypeAllowed.includes(companyProfile.type)) {
-        logger.debug(`${checkCompany.name} - Company Type ${companyProfile.type} for company number ${companyNumber} is not allowed`);
+        logger.debug(`Company Type ${companyProfile.type} for company with companyNumber="${companyNumber}" is not allowed`);
         res.redirect(addSearchParams(getUrlWithStopType(PrefixedUrls.STOP_SCREEN, STOP_TYPE.COMPANY_TYPE), { companyNumber, lang }));
     } else {
         next();

--- a/src/middleware/error-interceptors/dataIntegrityErrorInterceptor.ts
+++ b/src/middleware/error-interceptors/dataIntegrityErrorInterceptor.ts
@@ -5,7 +5,7 @@ import { PrefixedUrls, STOP_TYPE } from "../../constants";
 import { getUrlWithStopType } from "../../utils/url";
 import { logger } from "../../lib/logger";
 
-export function dataIntegrityErrorInterceptor (err: Error | DataIntegrityError, req: Request, res: Response, next: NextFunction): void {
+export function dataIntegrityErrorInterceptor (err: Error | DataIntegrityError, _: Request, res: Response, next: NextFunction): void {
     if (!(err instanceof DataIntegrityError)) {
         return next(err);
     }
@@ -17,6 +17,4 @@ export function dataIntegrityErrorInterceptor (err: Error | DataIntegrityError, 
     } else {
         return next(new Error(`Unhandled DataIntegrityError type: ${err.type}`));
     }
-
-    return next();
 }

--- a/src/middleware/error-interceptors/dataIntegrityErrorInterceptor.ts
+++ b/src/middleware/error-interceptors/dataIntegrityErrorInterceptor.ts
@@ -2,14 +2,14 @@ import { NextFunction, Request, Response } from "express";
 import { DataIntegrityError, DataIntegrityErrorType } from "../../lib/errors/dataIntegrityError";
 import { HttpStatusCode } from "axios";
 import { PrefixedUrls, STOP_TYPE } from "../../constants";
-import { logger } from "../../lib/logger";
 import { getUrlWithStopType } from "../../utils/url";
+import { logger } from "../../lib/logger";
 
 export function dataIntegrityErrorInterceptor (err: Error | DataIntegrityError, req: Request, res: Response, next: NextFunction): void {
     if (!(err instanceof DataIntegrityError)) {
         return next(err);
     }
-    logger.error(`${err.name} (${err.type}): ${err.stack}`);
+    logger.error(`${err.stack}`);
 
     if (err.type === DataIntegrityErrorType.PSC_DATA) {
         res.status(HttpStatusCode.InternalServerError);

--- a/src/middleware/error-interceptors/httpErrorInterceptor.ts
+++ b/src/middleware/error-interceptors/httpErrorInterceptor.ts
@@ -41,8 +41,8 @@ export const httpErrorInterceptor = (error: HttpError | Error, req: Request, res
     // Check if the template exists, else fallback to ISE template
     try {
         njk.getTemplate(TEMPLATE_PATH_ROOT + templateName + ".njk");
-    } catch (error: any) {
-        logger.error(`${error.message}. Falling back to error/${FALLBACK_TEMPLATE_NAME}.njk`);
+    } catch (err: any) {
+        logger.error(`${err.message}. Falling back to error/${FALLBACK_TEMPLATE_NAME}.njk`);
         templateName = FALLBACK_TEMPLATE_NAME;
     }
 

--- a/src/middleware/fetchCompany.ts
+++ b/src/middleware/fetchCompany.ts
@@ -11,7 +11,7 @@ export const fetchCompany = handleExceptions(async (req: Request, res: Response,
         logger.debug(`Retrieving company profile for company with companyNumber="${companyNumber}" ...`);
 
         const response: CompanyProfile = await getCompanyProfile(req, companyNumber);
-        // store the profile in the request.locals (per express SOP)
+        // store the profile in the res.locals (per express SOP)
         res.locals.companyProfile = response;
     } else {
         logger.error(`Cannot retrieve company profile: No company number provided`);

--- a/src/middleware/fetchCompany.ts
+++ b/src/middleware/fetchCompany.ts
@@ -8,13 +8,13 @@ export const fetchCompany = handleExceptions(async (req: Request, res: Response,
     const companyNumber = res.locals.submission?.data?.companyNumber || req.query.companyNumber;
 
     if (companyNumber) {
-        logger.debug(`${fetchCompany.name} - Retrieving company profile for company number ${companyNumber} ...`);
+        logger.debug(`Retrieving company profile for company with companyNumber="${companyNumber}" ...`);
 
         const response: CompanyProfile = await getCompanyProfile(req, companyNumber);
         // store the profile in the request.locals (per express SOP)
         res.locals.companyProfile = response;
     } else {
-        logger.error(`${fetchCompany.name} -  Cannot retrieve company profile: No company number provided`);
+        logger.error(`Cannot retrieve company profile: No company number provided`);
     }
     next();
 });

--- a/src/middleware/fetchVerification.ts
+++ b/src/middleware/fetchVerification.ts
@@ -11,7 +11,7 @@ export const fetchVerification = handleExceptions(async (req: Request, res: Resp
         logger.debug(`Retrieving verification: transactionId="${transactionId}", resourceId="${resourceId}"`);
 
         const response = await getPscVerification(req, transactionId, resourceId);
-        // store the submission in the request.locals (per express SOP)
+        // store the submission in the res.locals (per express SOP)
         res.locals.submission = response.resource;
     } else {
         logger.error(`No transactionId or resourceId found in request path parameters`);

--- a/src/middleware/fetchVerification.ts
+++ b/src/middleware/fetchVerification.ts
@@ -8,13 +8,13 @@ export const fetchVerification = handleExceptions(async (req: Request, res: Resp
     const transactionId = req.params.transactionId;
 
     if (transactionId && resourceId) {
-        logger.debug(`${fetchVerification.name} - Retrieving verification resourceID ${resourceId} ...`);
+        logger.debug(`Retrieving verification: transactionId="${transactionId}", resourceId="${resourceId}"`);
 
         const response = await getPscVerification(req, transactionId, resourceId);
         // store the submission in the request.locals (per express SOP)
         res.locals.submission = response.resource;
     } else {
-        logger.error(`${fetchVerification.name} - No transactionId or submissionId found in request path parameters`);
+        logger.error(`No transactionId or resourceId found in request path parameters`);
     }
     next();
 });

--- a/src/middleware/serviceUnavailable.ts
+++ b/src/middleware/serviceUnavailable.ts
@@ -9,7 +9,7 @@ import { HttpStatusCode } from "axios";
 
 export const serviceUnavailable = handleExceptions(async (req: Request, res: Response, next: NextFunction) => {
 
-    logger.debug(`${serviceUnavailable.name} - Service Availability check`);
+    logger.debug(`Service Availability check`);
 
     const response: ApiResponse<PlannedMaintenance> = await checkPlannedMaintenance(req);
 

--- a/src/routers/handlers/confirm-company/companyNumber.ts
+++ b/src/routers/handlers/confirm-company/companyNumber.ts
@@ -8,13 +8,13 @@ import { BaseViewData, GenericHandler } from "./../generic";
 export class CompanyNumberHandler extends GenericHandler<BaseViewData> {
 
     public execute (req: Request, _response: Response) {
-        logger.info(`${CompanyNumberHandler.name} - ${this.execute.name} called`);
+        logger.info(`called`);
 
         const lang = selectLang(req.query.lang);
         const forward = decodeURI(addSearchParams(ExternalUrls.COMPANY_LOOKUP_FORWARD, { companyNumber: "{companyNumber}", lang }));
         // addSearchParams() encodes the URI, so need to decode value before second call
         const companyLookup = addSearchParams(ExternalUrls.COMPANY_LOOKUP, { forward });
-        logger.debug(`${CompanyNumberHandler.name} - ${this.execute.name}: Company number redirect: ` + companyLookup);
+        logger.debug(`Company number redirect: ` + companyLookup);
 
         return _response.redirect(companyLookup);
     }

--- a/src/routers/handlers/confirm-company/companyNumber.ts
+++ b/src/routers/handlers/confirm-company/companyNumber.ts
@@ -7,7 +7,7 @@ import { BaseViewData, GenericHandler } from "./../generic";
 
 export class CompanyNumberHandler extends GenericHandler<BaseViewData> {
 
-    public execute (req: Request, _response: Response) {
+    public execute (req: Request, res: Response) {
         logger.info(`called`);
 
         const lang = selectLang(req.query.lang);
@@ -16,6 +16,6 @@ export class CompanyNumberHandler extends GenericHandler<BaseViewData> {
         const companyLookup = addSearchParams(ExternalUrls.COMPANY_LOOKUP, { forward });
         logger.debug(`Company number redirect: ` + companyLookup);
 
-        return _response.redirect(companyLookup);
+        return res.redirect(companyLookup);
     }
 }

--- a/src/routers/handlers/confirm-company/confirmCompany.ts
+++ b/src/routers/handlers/confirm-company/confirmCompany.ts
@@ -43,7 +43,7 @@ export class ConfirmCompanyHandler extends GenericHandler<ConfirmCompanyViewData
     }
 
     public async executeGet (req: Request, res: Response): Promise<ViewModel<ConfirmCompanyViewData>> {
-        logger.info(`${ConfirmCompanyHandler.name} - ${this.executeGet.name} called`);
+        logger.info(`called`);
 
         const viewData = await this.getViewData(req, res);
         return {
@@ -53,7 +53,7 @@ export class ConfirmCompanyHandler extends GenericHandler<ConfirmCompanyViewData
     }
 
     public async executePost (req: Request, res: Response) {
-        logger.info(`${ConfirmCompanyHandler.name} - ${this.executePost.name} called`);
+        logger.info(`called`);
         const companyNumber = req.body.companyNumber as string;
         const lang = selectLang(req.body.lang);
         return addSearchParams(PrefixedUrls.INDIVIDUAL_PSC_LIST, { companyNumber, lang });

--- a/src/routers/handlers/individual-psc-list/individualPscListHandler.ts
+++ b/src/routers/handlers/individual-psc-list/individualPscListHandler.ts
@@ -109,7 +109,7 @@ export class IndividualPscListHandler extends GenericHandler<IndividualPscListVi
                 } catch (error) {
                     // not able to add the verification state to the PSC object, but we still add the PSC object to the list
                     // this is to ensure that the user can still see the PSC in the list, and submit a verification
-                    logger.error(`${IndividualPscListHandler.name} - ${this.getViewData.name} - Error getting PSC individual details: ${error}`);
+                    logger.error(`Error getting PSC individual details: ${error}`);
                     individualPscListWithVerificationState.push(psc as PersonWithSignificantControl);
                 }
             }
@@ -118,7 +118,7 @@ export class IndividualPscListHandler extends GenericHandler<IndividualPscListVi
     }
 
     public async executeGet (req: Request, res: Response): Promise<ViewModel<IndividualPscListViewData>> {
-        logger.info(`${IndividualPscListHandler.name} - ${this.executeGet.name} `);
+        logger.info(`called`);
         const viewData = await this.getViewData(req, res);
 
         return {

--- a/src/routers/handlers/individual-statement/individualStatementHandler.ts
+++ b/src/routers/handlers/individual-statement/individualStatementHandler.ts
@@ -55,7 +55,7 @@ export class IndividualStatementHandler extends GenericHandler<IndividualStateme
     }
 
     public async executeGet (req: Request, res: Response): Promise<ViewModel<IndividualStatementViewData>> {
-        logger.info(`${IndividualStatementHandler.name} - ${this.executeGet.name} called for transaction: ${req.params?.transactionId} and submissionId: ${req.params?.submissionId}`);
+        logger.info(`called for transactionId="${req.params?.transactionId}", submissionId="${req.params?.submissionId}"`);
         const viewData = await this.getViewData(req, res);
 
         return {
@@ -65,7 +65,7 @@ export class IndividualStatementHandler extends GenericHandler<IndividualStateme
     }
 
     public async executePost (req: Request, res: Response): Promise<ViewModel<IndividualStatementViewData>> {
-        logger.info(`${IndividualStatementHandler.name} - ${this.executePost.name} called for transaction: ${req.params?.transactionId} and submissionId: ${req.params?.submissionId}`);
+        logger.info(`called for transactionId="${req.params?.transactionId}", submissionId="${req.params?.submissionId}"`);
         const viewData = await this.getViewData(req, res);
 
         try {
@@ -90,11 +90,11 @@ export class IndividualStatementHandler extends GenericHandler<IndividualStateme
             const nextPageUrl = getUrlWithTransactionIdAndSubmissionId(PrefixedUrls.PSC_VERIFIED, req.params.transactionId, req.params.submissionId);
             viewData.nextPageUrl = `${nextPageUrl}?${queryParams}`;
 
-            logger.debug(`${IndividualStatementHandler.name} - ${this.executePost.name} - patching individual verification statement for transaction: ${req.params?.transactionId} and submissionId: ${req.params?.submissionId}`);
+            logger.debug(`patching individual verification statement for transactionId="${req.params?.transactionId}", submissionId="${req.params?.submissionId}"`);
             await patchPscVerification(req, req.params.transactionId, req.params.submissionId, verification);
 
         } catch (err: any) {
-            logger.info(`There was a problem executing ${req.method} for individual verification statement for transaction: ${req.params?.transactionId} and submissionId: ${req.params?.submissionId}`);
+            logger.debug(`There was a problem executing ${req.method} for individual verification statement for transactionId="${req.params?.transactionId}", submissionId="${req.params?.submissionId}"`);
             viewData.errors = this.processHandlerException(err);
         }
 

--- a/src/routers/handlers/name-mismatch/nameMismatchHandler.ts
+++ b/src/routers/handlers/name-mismatch/nameMismatchHandler.ts
@@ -65,7 +65,7 @@ export class NameMismatchHandler extends GenericHandler<NameMismatchViewData> {
     }
 
     public async executeGet (req: Request, res: Response): Promise<ViewModel<NameMismatchViewData>> {
-        logger.info(`${NameMismatchHandler.name} - ${this.executeGet.name} called for transaction: ${req.params?.transactionId} and submissionId: ${req.params?.submissionId}`);
+        logger.info(`called for transactionId="${req.params?.transactionId}", submissionId="${req.params?.submissionId}"`);
         const viewData = await this.getViewData(req, res);
 
         return {
@@ -75,7 +75,7 @@ export class NameMismatchHandler extends GenericHandler<NameMismatchViewData> {
     }
 
     public async executePost (req: Request, res: Response): Promise<ViewModel<NameMismatchViewData>> {
-        logger.info(`${NameMismatchHandler.name} - ${this.executePost.name} called for transaction: ${req.params?.transactionId} and submissionId: ${req.params?.submissionId}`);
+        logger.info(`called for transactionId="${req.params?.transactionId}", submissionId="${req.params?.submissionId}"`);
         const viewData = await this.getViewData(req, res);
 
         try {
@@ -95,11 +95,11 @@ export class NameMismatchHandler extends GenericHandler<NameMismatchViewData> {
             const validator = new PscVerificationFormsValidator(lang);
             viewData.errors = await validator.validateNameMismatch(req.body, lang, viewData.pscName);
 
-            logger.debug(`${NameMismatchHandler.name} - ${this.executePost.name} - patching name mismatch reason for transaction: ${req.params?.transactionId} and submissionId: ${req.params?.submissionId}`);
+            logger.debug(`patching name mismatch reason for transactionId="${req.params?.transactionId}", submissionId="${req.params?.submissionId}"`);
             await patchPscVerification(req, req.params.transactionId, req.params.submissionId, verification);
 
         } catch (err: any) {
-            logger.error(`${req.method} error: problem handling name mismatch request: ${err.message}`);
+            logger.debug(`problem handling name mismatch request: ${err.message}`);
             viewData.errors = this.processHandlerException(err);
         }
 

--- a/src/routers/handlers/new-submission/newSubmissionHandler.ts
+++ b/src/routers/handlers/new-submission/newSubmissionHandler.ts
@@ -16,10 +16,10 @@ import { HttpStatusCode } from "axios";
 export class NewSubmissionHandler extends GenericHandler<BaseViewData> {
 
     public async execute (req: Request, res: Response) {
-        logger.info(`${NewSubmissionHandler.name} - ${this.execute.name} called`);
+        logger.info(`called`);
         // create a new transaction
         const transaction: Transaction = await postTransaction(req);
-        logger.info(`${NewSubmissionHandler.name} - ${this.execute.name} - CREATED Transaction ${transaction.id!}`);
+        logger.info(`CREATED transaction with transactionId="${transaction.id}"`);
 
         // create a new submission for the company number provided
         const resource = await this.createNewSubmission(req, transaction);
@@ -29,14 +29,10 @@ export class NewSubmissionHandler extends GenericHandler<BaseViewData> {
         let nextPageUrl : string = "";
 
         if (this.isErrorResponse(resource)) {
-
             nextPageUrl = getUrlWithStopType(PrefixedUrls.STOP_SCREEN, STOP_TYPE.PROBLEM_WITH_PSC_DATA);
-
         } else {
-
             const pscVerification = resource.resource;
-
-            logger.info(`${NewSubmissionHandler.name} - ${this.execute.name} - CREATED New Resource ${pscVerification?.links.self}`);
+            logger.info(`CREATED New Resource ${pscVerification?.links.self}`);
 
             // set up redirect to psc_code screen
             const regex = "persons-with-significant-control-verification/(.*)$";

--- a/src/routers/handlers/personal-code/personalCodeHandler.ts
+++ b/src/routers/handlers/personal-code/personalCodeHandler.ts
@@ -52,7 +52,7 @@ export class PersonalCodeHandler extends GenericHandler<PersonalCodeViewData> {
     }
 
     public async executeGet (req: Request, res: Response): Promise<ViewModel<PersonalCodeViewData>> {
-        logger.info(`${PersonalCodeHandler.name} - ${this.executeGet.name} called for transaction: ${req.params?.transactionId} and submissionId: ${req.params?.submissionId}`);
+        logger.info(`called for transactionId="${req.params?.transactionId}", submissionId="${req.params?.submissionId}"`);
         const viewData = await this.getViewData(req, res);
 
         return {
@@ -62,7 +62,7 @@ export class PersonalCodeHandler extends GenericHandler<PersonalCodeViewData> {
     }
 
     public async executePost (req: Request, res: Response): Promise<ViewModel<PersonalCodeViewData>> {
-        logger.info(`${PersonalCodeHandler.name} - ${this.executePost.name} called for transaction: ${req.params?.transactionId} and submissionId: ${req.params?.submissionId}`);
+        logger.info(`called for transactionId="${req.params?.transactionId}", submissionId="${req.params?.submissionId}"`);
         const viewData = await this.getViewData(req, res);
 
         try {
@@ -82,7 +82,7 @@ export class PersonalCodeHandler extends GenericHandler<PersonalCodeViewData> {
             const validator = new PscVerificationFormsValidator(lang);
             viewData.errors = await validator.validatePersonalCode(req.body, lang, viewData.pscName);
 
-            logger.debug(`${PersonalCodeHandler.name} - ${this.executePost.name} - patching personal code for transaction: ${req.params?.transactionId} and submissionId: ${req.params?.submissionId}`);
+            logger.debug(`patching personal code for transactionId="${req.params?.transactionId}", submissionId="${req.params?.submissionId}"`);
             const patchResponse = await patchPscVerification(req, req.params.transactionId, req.params.submissionId, verification);
             const validationStatusResponse = await getValidationStatus(req, req.params.transactionId, req.params.submissionId);
             const url = this.resolveNextPageUrl(validationStatusResponse, patchResponse);
@@ -90,7 +90,7 @@ export class PersonalCodeHandler extends GenericHandler<PersonalCodeViewData> {
             viewData.nextPageUrl = `${nextPageUrl}?${queryParams}`;
 
         } catch (err: any) {
-            logger.error(`${req.method} error: problem handling PSC details (personal code) request: ${err.message}`);
+            logger.debug(`problem handling personal code request: ${err.message}`);
             viewData.errors = this.processHandlerException(err);
         }
 

--- a/src/routers/handlers/psc-verified/pscVerifiedHandler.ts
+++ b/src/routers/handlers/psc-verified/pscVerifiedHandler.ts
@@ -51,16 +51,16 @@ export class PscVerifiedHandler extends GenericHandler<PscVerifiedViewData> {
     }
 
     public async executeGet (req: Request, res: Response): Promise<ViewModel<PscVerifiedViewData>> {
-        logger.info(`${PscVerifiedHandler.name} - ${this.executeGet.name} called for transaction: ${req.params?.transactionId} and ${req.params?.submissionId}`);
+        logger.info(`called for transactionId="${req.params?.transactionId}", submissionId="${req.params?.submissionId}"`);
         const viewData = await this.getViewData(req, res);
 
         await closeTransaction(req, req.params.transactionId, req.params.submissionId)
             .then((data) => {
-                console.log(data);
+                logger.info(`transaction closed successfully for transactionId="${req.params?.transactionId}", submissionId="${req.params?.submissionId}"`);
             })
             .catch((err) => {
-            // TODO: handle failure properly (redirect to Error Screen? TBC)
-                console.log(err);
+                // TODO: handle failure properly (redirect to Error Screen? TBC)
+                logger.error(`error closing transaction for transactionId="${req.params?.transactionId}", submissionId="${req.params?.submissionId}": ${err.message}`);
             });
 
         return {

--- a/src/routers/handlers/service-unavailable/serviceUnavailableHandler.ts
+++ b/src/routers/handlers/service-unavailable/serviceUnavailableHandler.ts
@@ -32,7 +32,7 @@ export default class ServiceUnavailableHandler extends GenericHandler<ServiceUna
     }
 
     public async executeGet (req: Request, res: Response): Promise<ViewModel<ServiceUnavailableViewData>> {
-        logger.info(`${ServiceUnavailableHandler.name} - ${this.executeGet.name}: called to serve Service Unavailable page`);
+        logger.info(`called to serve Service Unavailable page`);
 
         return {
             templatePath: ServiceUnavailableHandler.templatePath,

--- a/src/routers/handlers/start/startHandler.ts
+++ b/src/routers/handlers/start/startHandler.ts
@@ -33,7 +33,7 @@ export default class StartHandler extends GenericHandler<StartViewData> {
     }
 
     public async executeGet (req: Request, res: Response): Promise<ViewModel<StartViewData>> {
-        logger.info(`${StartHandler.name} - ${this.executeGet.name}: called to serve start page`);
+        logger.info(`called to serve start page`);
 
         // ...process request here and return data for the view
         return {

--- a/src/routers/individualPscListRouter.ts
+++ b/src/routers/individualPscListRouter.ts
@@ -17,10 +17,10 @@ individualPscListRouter.get("/", handleExceptions(async (req: Request, res: Resp
     const { templatePath, viewData } = await handler.executeGet(req, res);
 
     if (viewData.exclusivelySuperSecure) {
-        logger.debug(`individualPscListRouter.get - PSCs are exclusively Super Secure for company number ${companyNumber}: paper filing is required`);
+        logger.debug(`PSCs are exclusively Super Secure for companyNumber="${companyNumber}": paper filing is required`);
         res.redirect(addSearchParams(getUrlWithStopType(PrefixedUrls.STOP_SCREEN, STOP_TYPE.SUPER_SECURE), { companyNumber, lang }));
     } else if (viewData.showNoPscsMessage) {
-        logger.debug(`individualPscListRouter.get - there are no PSCs for company number ${companyNumber}`);
+        logger.debug(`there are no PSCs for companyNumber="${companyNumber}"`);
         res.redirect(addSearchParams(getUrlWithStopType(PrefixedUrls.STOP_SCREEN, STOP_TYPE.EMPTY_PSC_LIST), { companyNumber, lang }));
     } else {
         res.render(templatePath, viewData);

--- a/src/routers/utils/index.ts
+++ b/src/routers/utils/index.ts
@@ -19,7 +19,7 @@ export function formatDateBorn (dateOfBirth: any, lang: string): string {
         const formattedYear = dateOfBirth?.year?.toString() || ""; // Default to an empty string if year is null or undefined
         return `${formattedMonth} ${formattedYear}`;
     } catch (error) {
-        logger.error(`${formatDateBorn.name} - Error formatting date: ${error}`);
+        logger.error(`Error formatting date: ${error}`);
         return "Invalid date";
     }
 }
@@ -28,7 +28,7 @@ export function internationaliseDate (date: string, lang: string): string {
     try {
         return Intl.DateTimeFormat(lang === "en" ? "en-GB" : lang, { dateStyle: "long" }).format(new Date(date));
     } catch (error) {
-        logger.error(`${internationaliseDate.name} - Error internationalising date: ${error}`);
+        logger.error(`Error internationalising date: ${error}`);
         return "Invalid date";
     }
 }

--- a/src/services/companyProfileService.ts
+++ b/src/services/companyProfileService.ts
@@ -4,30 +4,30 @@ import { CompanyProfile } from "@companieshouse/api-sdk-node/dist/services/compa
 import { HttpStatusCode } from "axios";
 import { Request } from "express";
 import { createOAuthApiClient } from "./apiClientService";
-import { createAndLogError, logger } from "../lib/logger";
+import { logger } from "../lib/logger";
 import { ApiErrorResponse } from "@companieshouse/api-sdk-node/dist/services/resource";
 
 export const getCompanyProfile = async (request: Request, companyNumber: string): Promise<CompanyProfile> => {
     const oAuthApiClient: ApiClient = createOAuthApiClient(request.session);
 
-    logger.debug(`${getCompanyProfile.name} - Get company profile with company number ${companyNumber}`);
+    logger.debug(`Get company profile with companyNumber="${companyNumber}"`);
     const sdkResponse: Resource<CompanyProfile> | ApiErrorResponse = await oAuthApiClient.companyProfile.getCompanyProfile(companyNumber);
 
     if (!sdkResponse) {
-        throw createAndLogError(`${getCompanyProfile.name} - Company Profile API returned no response for company number ${companyNumber}`);
+        throw new Error(`Company Profile API returned no response for companyNumber="${companyNumber}"`);
     }
 
     if (!sdkResponse.httpStatusCode || sdkResponse.httpStatusCode !== HttpStatusCode.Ok) {
-        throw createAndLogError(`${getCompanyProfile.name} -HTTP status code ${sdkResponse.httpStatusCode} - Failed to get company profile for company number ${companyNumber}`);
+        throw new Error(`HTTP status code ${sdkResponse.httpStatusCode} - Failed to get company profile for companyNumber="${companyNumber}"`);
     }
 
     const castedSdkResponse = sdkResponse as Resource<CompanyProfile>;
 
     if (!castedSdkResponse.resource) {
-        throw createAndLogError(`${getCompanyProfile.name} - Company Profile API returned no resource for company number ${companyNumber}`);
+        throw new Error(`Company Profile API returned no resource for companyNumber="${companyNumber}"`);
     }
 
-    logger.debug(`${getCompanyProfile.name} - Received company profile ${JSON.stringify(sdkResponse)}`);
+    logger.debug(`Successfully received company profile with companyNumber="${companyNumber}"`);
 
     return castedSdkResponse.resource;
 };

--- a/src/services/pscService.ts
+++ b/src/services/pscService.ts
@@ -3,27 +3,26 @@ import ApiClient from "@companieshouse/api-sdk-node/dist/client";
 import { PersonWithSignificantControl } from "@companieshouse/api-sdk-node/dist/services/psc/types";
 import { ApiErrorResponse } from "@companieshouse/api-sdk-node/dist/services/resource";
 import { HttpStatusCode } from "axios";
-import { createAndLogError, logger } from "../lib/logger";
+import { logger } from "../lib/logger";
 import { createApiKeyClient } from "./apiClientService";
 
 export const getPscIndividual = async (companyNumber: string, pscNotificationId: string): Promise<Resource<PersonWithSignificantControl>> => {
     const apiClient: ApiClient = createApiKeyClient();
 
-    logger.debug(`${getPscIndividual.name} - for companyNumber: ${companyNumber} and PSC notification ID: ${pscNotificationId}`);
+    logger.debug(`for company with companyNumber="${companyNumber}", notificationId="${pscNotificationId}"`);
     const sdkResponse: Resource<PersonWithSignificantControl> | ApiErrorResponse = await apiClient.pscService.getPscIndividual(companyNumber, pscNotificationId);
 
     if (sdkResponse?.httpStatusCode !== HttpStatusCode.Ok) {
         if (sdkResponse?.httpStatusCode) {
-            logger.error(`${getPscIndividual.name} - sdk responded with HTTP status code: ${sdkResponse.httpStatusCode}`);
+            logger.error(`sdk responded with HTTP status code ${sdkResponse.httpStatusCode}`);
         }
-        throw createAndLogError(`${getPscIndividual.name} -  Failed to get PSC with verification state for companyNumber: ${companyNumber} and PSC notification ID: ${pscNotificationId}`);
+        throw new Error(`Failed to get PSC with verification state for companyNumber="${companyNumber}", notificationId="${pscNotificationId}"`);
     }
 
-    logger.debug(`${getPscIndividual.name} - response: ${JSON.stringify(sdkResponse)}`);
     const PscSdkResponse = sdkResponse as Resource<PersonWithSignificantControl>;
 
     if (!PscSdkResponse.resource) {
-        throw createAndLogError(`${getPscIndividual.name} - no PSC with verification state returned for companyNumber: ${companyNumber} and PSC notification ID: ${pscNotificationId}`);
+        throw new Error(`no PSC with verification state returned for companyNumber="${companyNumber}", notificationId="${pscNotificationId}"`);
     }
 
     return PscSdkResponse;

--- a/src/services/pscVerificationService.ts
+++ b/src/services/pscVerificationService.ts
@@ -13,102 +13,104 @@ import { DataIntegrityError, DataIntegrityErrorType } from "../lib/errors/dataIn
 
 export const createPscVerification = async (request: Request, transaction: Transaction, pscVerification: PscVerificationData): Promise<Resource<PscVerification> | ApiErrorResponse> => {
     if (!pscVerification) {
-        throw new Error(`${createPscVerification.name} - Aborting: PscVerificationData is required for PSC Verification POST request for transaction ${transaction.id}`);
+        throw new Error(`Aborting: PscVerificationData is required for PSC Verification POST request for transactionId="${transaction.id}"`);
     }
     if (!pscVerification.companyNumber) {
-        throw new Error(`${createPscVerification.name} - Aborting: companyNumber is required for PSC Verification POST request for transaction ${transaction.id}.`);
+        throw new Error(`Aborting: companyNumber is required for PSC Verification POST request for transactionId="${transaction.id}"`);
     }
     if (pscVerification.pscNotificationId == null) {
-        throw new DataIntegrityError(`${createPscVerification.name} - Aborting: pscNotificationId is required for PSC Verification POST request for transaction ${transaction.id}.`, DataIntegrityErrorType.PSC_DATA);
+        throw new DataIntegrityError(`Aborting: pscNotificationId is required for PSC Verification POST request for transactionId="${transaction.id}"`, DataIntegrityErrorType.PSC_DATA);
     }
 
     const oAuthApiClient: ApiClient = createOAuthApiClient(request.session);
 
-    logger.debug(`Creating PSC verification resource for ${transaction.description} transaction ${transaction.id}`);
+    logger.debug(`Creating PSC verification resource for transactionId="${transaction.id}": ${transaction.description}`);
     const sdkResponse: Resource<PscVerification> | ApiErrorResponse = await oAuthApiClient.pscVerificationService.postPscVerification(transaction.id as string, pscVerification);
 
     if (!sdkResponse) {
-        throw new Error(`${createPscVerification.name} - PSC Verification POST request returned no response for transaction ${transaction.id}`);
+        throw new Error(`PSC Verification POST request returned no response for transactionId="${transaction.id}"`);
     }
 
     if (sdkResponse.httpStatusCode === HttpStatusCode.InternalServerError) {
         const error = ((sdkResponse as ApiErrorResponse).errors?.[0] as ApiErrorResponse).errors?.[0].errorValues?.error as string;
 
         if (RegExp(Responses.PROBLEM_WITH_PSC_DATA as string).exec(error)) {
-            throw new DataIntegrityError(`${createPscVerification.name} - ${Responses.PROBLEM_WITH_PSC_DATA} - Failed to POST PSC Verification for transaction ${transaction.id}`, DataIntegrityErrorType.PSC_DATA);
+            throw new DataIntegrityError(`${Responses.PROBLEM_WITH_PSC_DATA} - Failed to POST PSC Verification for transactionId="${transaction.id}"`, DataIntegrityErrorType.PSC_DATA);
         }
     }
 
     if (!sdkResponse.httpStatusCode) {
-        throw new Error(`${createPscVerification.name} - HTTP status code is undefined - Failed to POST PSC Verification for transaction ${transaction.id}`);
+        throw new Error(`HTTP status code is undefined - Failed to POST PSC Verification for transactionId="${transaction.id}"`);
     } else if (sdkResponse.httpStatusCode === HttpStatusCode.BadRequest || sdkResponse.httpStatusCode === HttpStatusCode.NotFound) {
-        const message = (sdkResponse as any)?.resource?.errors?.[0]?.error ?? `Failed to POST PSC Verification for transaction ${transaction.id}`;
-        throw new DataIntegrityError(`${createPscVerification.name} received ${sdkResponse.httpStatusCode} - ${message}`, DataIntegrityErrorType.PSC_DATA);
+        const message = (sdkResponse as any)?.resource?.errors?.[0]?.error ?? `Failed to POST PSC Verification for transactionId="${transaction.id}"`;
+        throw new DataIntegrityError(`received ${sdkResponse.httpStatusCode} - ${message}`, DataIntegrityErrorType.PSC_DATA);
     } else if (sdkResponse.httpStatusCode !== HttpStatusCode.Created) {
-        throw new HttpError(`${createPscVerification.name} - Failed to POST PSC Verification for transaction ${transaction.id}`, sdkResponse.httpStatusCode);
+        throw new HttpError(`Failed to POST PSC Verification for transactionId="${transaction.id}"`, sdkResponse.httpStatusCode);
     }
 
     const castedSdkResponse = sdkResponse as Resource<PscVerification>;
 
     if (!castedSdkResponse.resource) {
-        throw new Error(`${createPscVerification.name} - PSC Verification API POST request returned no resource for transaction ${transaction.id}`);
+        throw new Error(`PSC Verification API POST request returned no resource for transactionId="${transaction.id}"`);
     }
-    logger.debug(`${createPscVerification.name} - POST PSC Verification response: ${JSON.stringify(sdkResponse)}`);
+    logger.debug(`POST PSC Verification finished with status ${sdkResponse.httpStatusCode} for transactionId="${transaction.id}"`);
 
     return castedSdkResponse;
 };
 
 export const getPscVerification = async (request: Request, transactionId: string, pscVerificationId: string): Promise<Resource<PscVerification>> => {
     const oAuthApiClient: ApiClient = createOAuthApiClient(request.session);
-    const logReference = `transaction ${transactionId}, pscVerification ${pscVerificationId}`;
+    const logReference = `transactionId="${transactionId}", pscVerificationId="${pscVerificationId}"`;
 
     logger.debug(`Retrieving PSC verification for ${logReference}`);
     const sdkResponse: Resource<PscVerification> | ApiErrorResponse = await oAuthApiClient.pscVerificationService.getPscVerification(transactionId, pscVerificationId);
 
     if (!sdkResponse) {
-        throw new Error(`${getPscVerification.name} - PSC Verification GET request returned no response for ${logReference}`);
+        throw new Error(`PSC Verification GET request returned no response for ${logReference}`);
     }
     switch (sdkResponse.httpStatusCode) {
         case HttpStatusCode.Ok:
             break; // Successful response, proceed further
         case HttpStatusCode.Unauthorized:
             // Show the Page Not Found page if the user is not authorized to view the resource
-            throw new HttpError(`${getPscVerification.name} - User not authorized owner for ${logReference}`, HttpStatusCode.NotFound);
+            throw new HttpError(`User not authorized owner for ${logReference}`, HttpStatusCode.NotFound);
 
         case undefined:
-            throw new Error(`${getPscVerification.name} - HTTP status code is undefined - Failed to GET PSC Verification for ${logReference}`);
+            throw new Error(`HTTP status code is undefined - Failed to GET PSC Verification for ${logReference}`);
         default:
-            throw new HttpError(`${getPscVerification.name} - Failed to GET PSC Verification for ${logReference}`, sdkResponse.httpStatusCode);
+            throw new HttpError(`Failed to GET PSC Verification for ${logReference}`, sdkResponse.httpStatusCode);
     }
 
     const castedSdkResponse = sdkResponse as Resource<PscVerification>;
 
     if (!castedSdkResponse.resource) {
-        throw new Error(`${getPscVerification.name} - PSC Verification API GET request returned no resource for ${logReference}`);
+        throw new Error(`PSC Verification API GET request returned no resource for ${logReference}`);
     }
-    logger.debug(`${getPscVerification.name} - GET PSC Verification response: ${sdkResponse.httpStatusCode}`);
+    logger.debug(`GET PSC Verification finished with status ${sdkResponse.httpStatusCode} for ${logReference}`);
 
     return castedSdkResponse;
 };
 
 export const patchPscVerification = async (request: Request, transactionId: string, pscVerificationId: string, pscVerification: PscVerificationData): Promise<Resource<PscVerification>> => {
     const oAuthApiClient: ApiClient = createOAuthApiClient(request.session);
-    const logReference = `transactionId ${transactionId}, pscVerificationId ${pscVerificationId}`;
+    const logReference = `transactionId="${transactionId}", pscVerificationId="${pscVerificationId}"`;
 
-    logger.debug(`Patching PSC verification resource with ${logReference}`);
+    logger.debug(`Patching PSC verification resource with with ${logReference}`);
     const sdkResponse: Resource<PscVerification> | ApiErrorResponse = await oAuthApiClient.pscVerificationService.patchPscVerification(transactionId, pscVerificationId, pscVerification);
 
     if (!sdkResponse) {
-        throw new Error(`${patchPscVerification.name} - PSC Verification PATCH request returned no response for resource with ${logReference}`);
+        throw new Error(`PSC Verification PATCH request returned no response for resource with ${logReference}`);
     }
 
     if (!sdkResponse.httpStatusCode) {
-        throw new Error(`${patchPscVerification.name} - HTTP status code is undefined - Failed to PATCH PSC Verification for resource with ${logReference}`);
+        throw new Error(`HTTP status code is undefined - Failed to PATCH PSC Verification for resource with ${logReference}`);
     } else if (sdkResponse.httpStatusCode === HttpStatusCode.BadRequest || sdkResponse.httpStatusCode === HttpStatusCode.NotFound) {
         const message = (sdkResponse as any)?.resource?.errors?.[0]?.error ?? `Failed to PATCH PSC Verification for resource with ${logReference}`;
-        throw new DataIntegrityError(`${patchPscVerification.name} received ${sdkResponse.httpStatusCode} - ${message}`, DataIntegrityErrorType.PSC_DATA);
+        const errorValues = (sdkResponse as any)?.resource?.errors?.[0]?.errorValues ?? {};
+        const errorContext = JSON.stringify(errorValues, null, 2);
+        throw new DataIntegrityError(`received ${sdkResponse.httpStatusCode} - ${message}, context: \n${errorContext}`, DataIntegrityErrorType.PSC_DATA);
     } else if (sdkResponse.httpStatusCode !== HttpStatusCode.Ok) {
-        throw new HttpError(`${patchPscVerification.name} - Failed to PATCH PSC Verification for resource with ${logReference}`, sdkResponse.httpStatusCode);
+        throw new HttpError(`Failed to PATCH PSC Verification for resource with ${logReference}`, sdkResponse.httpStatusCode);
     }
 
     const castedSdkResponse = sdkResponse as Resource<PscVerification>;
@@ -116,8 +118,7 @@ export const patchPscVerification = async (request: Request, transactionId: stri
     if (!castedSdkResponse.resource) {
         throw new Error(`PSC Verification API PATCH request returned no resource with ${logReference}`);
     }
-    logger.debug(`${patchPscVerification.name} - PATCH HTTP status code response for ${logReference}: ${sdkResponse.httpStatusCode}`);
-    logger.debug(`${patchPscVerification.name} - PATCH PSC Verification response for ${logReference}: ${JSON.stringify(sdkResponse)}`);
+    logger.debug(`PATCH PSC verification finished with status ${sdkResponse.httpStatusCode} for ${logReference}`);
 
     return castedSdkResponse;
 };
@@ -129,39 +130,39 @@ export const checkPlannedMaintenance = async (request: Request): Promise<ApiResp
     const sdkResponse: ApiResponse<PlannedMaintenance> | ApiErrorResponse = await apiClient.pscVerificationService.checkPlannedMaintenance();
 
     if (!sdkResponse) {
-        throw new Error(`${checkPlannedMaintenance.name} - PSC Verification GET maintenance request returned no response`);
+        throw new Error(`PSC Verification GET maintenance request returned no response`);
     }
     if (!sdkResponse.httpStatusCode || sdkResponse.httpStatusCode !== HttpStatusCode.Ok) {
-        throw new Error(`${checkPlannedMaintenance.name} - HTTP status code ${sdkResponse.httpStatusCode} - Failed to GET Planned Maintenance response`);
+        throw new Error(`HTTP status code ${sdkResponse.httpStatusCode} - Failed to GET Planned Maintenance response`);
     }
 
     const castedSdkResponse = sdkResponse as ApiResponse<PlannedMaintenance>;
-    logger.debug(`${checkPlannedMaintenance.name} - GET PSC Verification Planned Maintenance response: ${sdkResponse.httpStatusCode}`);
+    logger.debug(`GET PSC Verification Planned Maintenance finished with ${sdkResponse.httpStatusCode}`);
 
     return castedSdkResponse;
 };
 
 export const getValidationStatus = async (request: Request, transactionId: string, pscVerificationId: string): Promise<Resource<ValidationStatusResponse>> => {
     const oAuthApiClient: ApiClient = createOAuthApiClient(request.session);
-    const logReference = `transaction ${transactionId}, pscVerification ${pscVerificationId}`;
+    const logReference = `transactionId="${transactionId}", pscVerificationId="${pscVerificationId}"`;
 
     logger.debug(`Retrieving PSC verification validation status for ${logReference}`);
     const sdkResponse: Resource<ValidationStatusResponse> | ApiErrorResponse = await oAuthApiClient.pscVerificationService.getValidationStatus(transactionId, pscVerificationId);
 
     if (!sdkResponse) {
-        throw new Error(`${getValidationStatus.name} - PSC Verification GET validation status request did not return a response for ${logReference}`);
+        throw new Error(`PSC Verification GET validation status request did not return a response for ${logReference}`);
     }
 
     if (sdkResponse.httpStatusCode !== HttpStatusCode.Ok) {
-        throw new Error(`${getValidationStatus.name} - Error getting validation status: HTTP response is: ${sdkResponse.httpStatusCode} for ${logReference}`);
+        throw new Error(`Error getting validation status: HTTP response is ${sdkResponse.httpStatusCode} for ${logReference}`);
     }
 
     const validationStatus = sdkResponse as Resource<ValidationStatusResponse>;
 
     if (validationStatus.resource?.isValid === false) {
-        logger.error(`Validation errors for resource ${logReference}: ` + JSON.stringify(validationStatus.resource.errors.slice(0, 10)));
+        logger.error(`Validation errors for ${logReference}: ` + JSON.stringify(validationStatus.resource.errors.slice(0, 10)));
     } else if (validationStatus.resource?.isValid === undefined) {
-        throw new Error(`${getValidationStatus.name} - Error getting validation status for ${logReference}`);
+        throw new Error(`Error getting validation status for ${logReference}`);
     }
 
     return validationStatus;

--- a/src/services/transactionService.ts
+++ b/src/services/transactionService.ts
@@ -17,33 +17,32 @@ export enum TransactionStatus { OPEN = "open", CLOSED = "closed" }
 export const getTransaction = async (req: Request, transactionId: string): Promise<Transaction> => {
     const apiClient: ApiClient = createOAuthApiClient(req.session);
 
-    logger.debug(`${getTransaction.name} - Retrieving transaction with id ${transactionId}`);
+    logger.debug(`Retrieving transaction with transactionId="${transactionId}"`);
     const sdkResponse: Resource<Transaction> | ApiErrorResponse = await apiClient.transaction.getTransaction(transactionId);
 
     if (!sdkResponse) {
-        logger.error(`${getTransaction.name} - Transaction API GET request returned no response for transaction id ${transactionId}`);
-        return Promise.reject(new Error("No response from Transaction API"));
+        logger.error(`Transaction API GET request returned no response for transactionId="${transactionId}"`);
+        return Promise.reject(new Error(`No response from Transaction API for transactionId="${transactionId}"`));
     }
 
     if (!sdkResponse.httpStatusCode || sdkResponse.httpStatusCode >= HttpStatusCode.BadRequest) {
-        logger.error(`${getTransaction.name} - HTTP status code ${sdkResponse.httpStatusCode} - Failed to get transaction for transaction id ${transactionId}`);
-        return Promise.reject(new HttpError(`Failed to get transaction`, sdkResponse.httpStatusCode ?? HttpStatusCode.InternalServerError));
+        logger.error(`HTTP status code ${sdkResponse.httpStatusCode} - Failed to get transaction with transactionId="${transactionId}"`);
+        return Promise.reject(new HttpError(`Failed to get transaction with transactionId="${transactionId}"`, sdkResponse.httpStatusCode ?? HttpStatusCode.InternalServerError));
     }
 
     const castedSdkResponse: Resource<Transaction> = sdkResponse as Resource<Transaction>;
 
     if (!castedSdkResponse.resource) {
-        logger.error(`${getTransaction.name} - Transaction API GET request returned no resource for transaction id ${transactionId}`);
-        return Promise.reject(new Error("No resource in Transaction API response"));
+        logger.error(`Transaction API GET request returned no resource for transactionId="${transactionId}"`);
+        return Promise.reject(new Error(`No resource in Transaction API response for transactionId="${transactionId}"`));
     }
 
-    logger.debug(`${getTransaction.name} - Retrieved transaction: ${JSON.stringify(castedSdkResponse.resource)}`);
+    logger.debug(`Retrieved transaction with status code ${sdkResponse.httpStatusCode} for transactionId="${transactionId}"`);
 
     return Promise.resolve(castedSdkResponse.resource);
 };
 
 export const postTransaction = async (req: Request): Promise<Transaction> => {
-
     const companyNumber = req.query.companyNumber as string;
     const companyProfile: CompanyProfile = await getCompanyProfile(req, companyNumber);
     const companyName: string = companyProfile.companyName;
@@ -55,34 +54,32 @@ export const postTransaction = async (req: Request): Promise<Transaction> => {
         companyName: companyName
     };
 
-    logger.debug(`${postTransaction.name} - Creating transaction with company number ${companyNumber}`);
+    logger.debug(`Creating transaction with companyNumber="${companyNumber}"`);
     const sdkResponse: Resource<Transaction> | ApiErrorResponse = await oAuthApiClient.transaction.postTransaction(transaction);
 
     if (!sdkResponse) {
-        logger.error(`${postTransaction.name} - Transaction API POST request returned no response for company number ${companyNumber}`);
+        logger.error(`Transaction API POST request returned no response for companyNumber="${companyNumber}"`);
         return Promise.reject(sdkResponse);
     }
+
     if (!sdkResponse.httpStatusCode || sdkResponse.httpStatusCode >= HttpStatusCode.BadRequest) {
-        logger.error(`${postTransaction.name} - HTTP status code ${sdkResponse.httpStatusCode} - Failed to post transaction for company number ${companyNumber}`);
+        logger.error(`HTTP status code ${sdkResponse.httpStatusCode} - Failed to post transaction with companyNumber="${companyNumber}"`);
         return Promise.reject(sdkResponse);
     }
 
     const castedSdkResponse: Resource<Transaction> = sdkResponse as Resource<Transaction>;
 
     if (!castedSdkResponse.resource) {
-        logger.error(`${postTransaction.name} - Transaction API POST request returned no resource for company number ${companyNumber}`);
+        logger.error(`Transaction API POST request returned no resource for companyNumber="${companyNumber}"`);
         return Promise.reject(sdkResponse);
     }
-    logger.debug(`${postTransaction.name} - Received transaction: ${JSON.stringify(sdkResponse)}`);
+
+    logger.debug(`Received transaction with status code ${sdkResponse.httpStatusCode} for companyNumber="${companyNumber}"`);
 
     return Promise.resolve(castedSdkResponse.resource);
 };
 
-export const putTransaction = async (req: Request,
-    transactionId: string,
-    description: string,
-    transactionStatus: string,
-    objectId: string|undefined): Promise<ApiResponse<Transaction>> => {
+export const putTransaction = async (req: Request, transactionId: string, description: string, transactionStatus: string, objectId: string | undefined): Promise<ApiResponse<Transaction>> => {
     const apiClient: ApiClient = createOAuthApiClient(req.session);
 
     const transaction: Transaction = {
@@ -92,35 +89,36 @@ export const putTransaction = async (req: Request,
         status: transactionStatus
     };
 
-    logger.debug(`${putTransaction.name} - Updating transaction id ${transactionId} with status ${transactionStatus}`);
+    logger.debug(`Updating transaction with transactionId="${transactionId}", status="${transactionStatus}"`);
     const sdkResponse: ApiResponse<Transaction> | ApiErrorResponse = await apiClient.transaction.putTransaction(transaction);
 
     if (!sdkResponse) {
-        logger.error(`${putTransaction.name} - Transaction API PUT request returned no response for transaction id ${transactionId}`);
+        logger.error(`Transaction API PUT request returned no response for transactionId="${transactionId}"`);
         return Promise.reject(sdkResponse);
     }
 
     if (!sdkResponse.httpStatusCode || sdkResponse.httpStatusCode !== HttpStatusCode.NoContent) {
-        logger.error(`${putTransaction.name} - HTTP status code ${sdkResponse.httpStatusCode} - Failed to put transaction for transaction id ${transactionId}`);
+        logger.error(`HTTP status code ${sdkResponse.httpStatusCode} - Failed to put transaction with transactionId="${transactionId}"`);
         return Promise.reject(sdkResponse);
     }
 
     const castedSdkResponse: ApiResponse<Transaction> = sdkResponse as ApiResponse<Transaction>;
 
-    logger.debug(`${putTransaction.name} - Received transaction: ${JSON.stringify(sdkResponse)}`);
+    logger.debug(`Updated transaction with transactionId="${transactionId}"`);
 
     return Promise.resolve(castedSdkResponse);
 };
 
-export const closeTransaction = async (req: Request, transactionId: string, objectId: string|undefined): Promise<Resource<Transaction> | ApiErrorResponse> => {
-    logger.debug(`${closeTransaction.name} - Closing transaction id ${transactionId}, updating reference`);
+export const closeTransaction = async (req: Request, transactionId: string, objectId: string | undefined): Promise<Resource<Transaction> | ApiErrorResponse> => {
+    logger.debug(`Closing transaction with transactionId="${transactionId}", updating reference`);
 
     const putResponse: ApiResponse<Transaction> = await putTransaction(req, transactionId, DESCRIPTION, TransactionStatus.CLOSED, objectId)
         .catch((sdkResponse) => {
+            logger.error(`Failed to close transaction with transactionId="${transactionId}"`);
             return Promise.reject(sdkResponse);
         });
-    logger.debug(`${closeTransaction.name} - Closed transaction: ${JSON.stringify(putResponse)}`);
+
+    logger.debug(`Closed transaction with transactionId="${transactionId}"`);
 
     return Promise.resolve(putResponse);
-
 };

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -12,7 +12,7 @@ export const toReadableFormat = (dateToConvert: string | undefined, lang = "en")
     const convertedDate = dateTime.setLocale(lang).toFormat("d MMMM yyyy");
 
     if (convertedDate === "Invalid DateTime") {
-        throw logger.info(`${toReadableFormat.name} - Unable to convert provided date ${dateToConvert}`);
+        throw logger.info(`Unable to convert provided date ${dateToConvert}`);
     }
 
     return convertedDate;
@@ -34,7 +34,7 @@ export const toHourDayDateFormat = (dateToConvert: string | undefined, lang = "e
     const convertedDate = dateTime.setLocale(lang).toFormat("cccc d MMMM yyyy");
 
     if (convertedHour === "Invalid DateTime" || convertedDate === "Invalid DateTime") {
-        throw logger.info(`${toHourDayDateFormat.name} - Unable to convert provided date ${dateToConvert}`);
+        throw logger.info(`Unable to convert provided date ${dateToConvert}`);
     }
 
     const locales = getLocalesService();

--- a/test/lib/logger.unit.ts
+++ b/test/lib/logger.unit.ts
@@ -116,4 +116,16 @@ describe("PrefixedLogger", () => {
         expect(prefix).toBe("");
         expect(mockRawLogger.error).toHaveBeenCalledWith(expect.stringContaining("unable to extract log prefix from stack trace"));
     });
+
+    it("should log an error and return an empty string when the stack trace can't be parsed", () => {
+        const mockError = new Error();
+        mockError.stack = [
+            "Error: Test error",
+            "    THIS CANNOT BE PARSED",
+            "    at Object.<anonymous> (/path/to/test.ts:15:25)"
+        ].join("\n");
+        const prefix = logger.getPrefix({ error: mockError });
+        expect(prefix).toBe("");
+        expect(mockRawLogger.error).toHaveBeenCalledWith(expect.stringContaining("unable to extract log prefix from stack trace"));
+    });
 });

--- a/test/lib/logger.unit.ts
+++ b/test/lib/logger.unit.ts
@@ -1,24 +1,119 @@
-import { createAndLogError, logger } from "../../src/lib/logger";
+import { PrefixedLogger } from "../../src/lib/logger";
+import { Request } from "express";
+import { jest } from "@jest/globals";
 
-// create a mock logger
-jest.mock("@companieshouse/structured-logging-node", () => ({
-    createLogger: jest.fn(() => ({
-        error: jest.fn(),
-        debug: jest.fn(),
-        info: jest.fn(),
-        warn: jest.fn(),
-        trace: jest.fn()
-    }))
-}));
+describe("PrefixedLogger", () => {
+    let logger: PrefixedLogger;
+    let mockRawLogger: any;
 
-describe("logger", () => {
-    describe("createAndLogError", () => {
-        it("should create and log an error", () => {
-            const error = createAndLogError("Test error");
-            expect(error).toBeInstanceOf(Error);
-            expect(error.message).toBe("Test error");
-            expect(logger.error).toHaveBeenCalledWith(`${error.stack}`);
-        });
+    beforeEach(() => {
+        mockRawLogger = {
+            info: jest.fn(),
+            error: jest.fn(),
+            debug: jest.fn(),
+            trace: jest.fn(),
+            infoRequest: jest.fn(),
+            errorRequest: jest.fn(),
+            debugRequest: jest.fn(),
+            traceRequest: jest.fn()
+        };
+        jest.spyOn(require("@companieshouse/structured-logging-node"), "createLogger").mockReturnValue(mockRawLogger);
+        logger = new PrefixedLogger();
     });
 
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it("should log info messages with prefix", () => {
+        logger.info("Test info message");
+        expect(mockRawLogger.info).toHaveBeenCalledWith(expect.stringContaining("Test info message"));
+    });
+
+    it("should log error messages with prefix", () => {
+        logger.error("Test error message");
+        expect(mockRawLogger.error).toHaveBeenCalledWith(expect.stringContaining("Test error message"));
+    });
+
+    it("should log debug messages with prefix", () => {
+        logger.debug("Test debug message");
+        expect(mockRawLogger.debug).toHaveBeenCalledWith(expect.stringContaining("Test debug message"));
+    });
+
+    it("should log trace messages with prefix", () => {
+        logger.trace("Test trace message");
+        expect(mockRawLogger.trace).toHaveBeenCalledWith(expect.stringContaining("Test trace message"));
+    });
+
+    it("should log infoRequest messages with prefix", () => {
+        const mockRequest = {} as Request;
+        logger.infoRequest(mockRequest, "Test infoRequest message");
+        expect(mockRawLogger.infoRequest).toHaveBeenCalledWith(mockRequest, expect.stringContaining("Test infoRequest message"));
+    });
+
+    it("should log errorRequest messages with prefix", () => {
+        const mockRequest = {} as Request;
+        logger.errorRequest(mockRequest, "Test errorRequest message");
+        expect(mockRawLogger.errorRequest).toHaveBeenCalledWith(mockRequest, expect.stringContaining("Test errorRequest message"));
+    });
+
+    it("should log debugRequest messages with prefix", () => {
+        const mockRequest = {} as Request;
+        logger.debugRequest(mockRequest, "Test debugRequest message");
+        expect(mockRawLogger.debugRequest).toHaveBeenCalledWith(mockRequest, expect.stringContaining("Test debugRequest message"));
+    });
+
+    it("should log traceRequest messages with prefix", () => {
+        const mockRequest = {} as Request;
+        logger.traceRequest(mockRequest, "Test traceRequest message");
+        expect(mockRawLogger.traceRequest).toHaveBeenCalledWith(mockRequest, expect.stringContaining("Test traceRequest message"));
+    });
+
+    it("should generate a ClassName::methodName prefix from stack trace", () => {
+        const mockError = new Error();
+        mockError.stack = [
+            "Error: Test error",
+            "    at PrefixedLogger.getPrefix (/path/to/logger.ts:10:20)",
+            "    at Object.<anonymous> (/path/to/test.ts:15:25)"
+        ].join("\n");
+        const prefix = logger.getPrefix({ error: mockError });
+        expect(prefix).toBe("PrefixedLogger::getPrefix -");
+    });
+
+    it("should generate a methodName prefix from stack trace", () => {
+        const mockError = new Error();
+        mockError.stack = [
+            "Error: Test error",
+            "    at getPrefix (/path/to/logger.ts:10:20)",
+            "    at Object.<anonymous> (/path/to/test.ts:15:25)"
+        ].join("\n");
+        const prefix = logger.getPrefix({ error: mockError });
+        expect(prefix).toBe("getPrefix -");
+    });
+
+    it("should generate prefix from stack trace with filepath format", () => {
+        const mockError = new Error();
+        mockError.stack = [
+            "Error: Test error",
+            "    at /path/to/filename.ts:10:20",
+            "    at Object.<anonymous> (/path/to/test.ts:15:25)"
+        ].join("\n");
+        const prefix = logger.getPrefix({ error: mockError });
+        expect(prefix).toBe("filename -");
+    });
+
+    it("should handle missing stack trace gracefully", () => {
+        const error = new Error();
+        error.stack = undefined;
+        const prefix = logger.getPrefix({ error });
+        expect(prefix).toBe("");
+    });
+
+    it("should log an error and return an empty string when stack trace is invalid", () => {
+        const mockError = new Error();
+        mockError.stack = "Invalid stack trace format";
+        const prefix = logger.getPrefix({ error: mockError });
+        expect(prefix).toBe("");
+        expect(mockRawLogger.error).toHaveBeenCalledWith(expect.stringContaining("unable to extract log prefix from stack trace"));
+    });
 });

--- a/test/middleware/blockClosedTransaction.unit.ts
+++ b/test/middleware/blockClosedTransaction.unit.ts
@@ -62,7 +62,7 @@ describe("blockClosedTransaction middleware", () => {
         const req = generateRequest(PrefixedUrls.PERSONAL_CODE);
         const res = httpMocks.createResponse();
         const error401 = new HttpError("User not authorized owner for transaction", 401);
-        const error404 = new HttpError(`blockClosedTransaction - User not authorized owner for transaction ${TRANSACTION_ID}`, 404);
+        const error404 = new HttpError(`User not authorized owner for transactionId="${TRANSACTION_ID}"`, 404);
 
         mockGetTransaction.mockRejectedValueOnce(error401);
 

--- a/test/middleware/error-interceptors/dataIntegrityErrorInterceptor.unit.ts
+++ b/test/middleware/error-interceptors/dataIntegrityErrorInterceptor.unit.ts
@@ -34,7 +34,7 @@ describe("dataIntegrityErrorInterceptor", () => {
 
         dataIntegrityErrorInterceptor(error, req as Request, res as Response, next);
 
-        expect(logger.error).toHaveBeenCalledWith(`${error.name} (${error.type}): ${error.stack}`);
+        expect(logger.error).toHaveBeenCalledWith(`${error.stack}`);
         expect(res.status).toHaveBeenCalledWith(HttpStatusCode.InternalServerError);
         expect(res.redirect).toHaveBeenCalledWith("/persons-with-significant-control-verification/stop/problem-with-psc-data");
         expect(next).toHaveBeenCalled();

--- a/test/middleware/error-interceptors/dataIntegrityErrorInterceptor.unit.ts
+++ b/test/middleware/error-interceptors/dataIntegrityErrorInterceptor.unit.ts
@@ -37,7 +37,6 @@ describe("dataIntegrityErrorInterceptor", () => {
         expect(logger.error).toHaveBeenCalledWith(`${error.stack}`);
         expect(res.status).toHaveBeenCalledWith(HttpStatusCode.InternalServerError);
         expect(res.redirect).toHaveBeenCalledWith("/persons-with-significant-control-verification/stop/problem-with-psc-data");
-        expect(next).toHaveBeenCalled();
     });
 
     it("should pass unhandled DataIntegrityError types to the next middleware as a generic error", () => {

--- a/test/middleware/requestLogger.unit.ts
+++ b/test/middleware/requestLogger.unit.ts
@@ -37,8 +37,8 @@ describe("requestLogger middleware", () => {
     it("should log the request and response details", () => {
         requestLogger(req as Request, res as Response, next);
 
-        expect(logger.debugRequest).toHaveBeenCalledWith(req, expect.stringContaining("OPEN request with requestId=\"mock-id\""));
-        expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining("CLOSED request with requestId=\"mock-id\""));
+        expect(logger.raw.debugRequest).toHaveBeenCalledWith(req, expect.stringContaining("OPEN request with requestId=\"mock-id\""));
+        expect(logger.raw.debug).toHaveBeenCalledWith(expect.stringContaining("CLOSED request with requestId=\"mock-id\""));
         expect(next).toHaveBeenCalled();
     });
 
@@ -49,7 +49,7 @@ describe("requestLogger middleware", () => {
 
         requestLogger(req as Request, res as Response, next);
 
-        expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining("CLOSED request with requestId=\"mock-id\" after 6400.00ms"));
+        expect(logger.raw.debug).toHaveBeenCalledWith(expect.stringContaining("CLOSED request with requestId=\"mock-id\" after 6400.00ms"));
         mockHrtime.mockRestore();
     });
 
@@ -58,11 +58,11 @@ describe("requestLogger middleware", () => {
 
         requestLogger(req as Request, res as Response, next);
 
-        expect(logger.error).toHaveBeenCalledWith(
-            `${requestLogger.name} - Request ID is missing. Ensure that the 'requestIdGenerator' middleware is called before this middleware.`
+        expect(logger.raw.error).toHaveBeenCalledWith(
+            expect.stringContaining(`Request ID is missing. Ensure that the 'requestIdGenerator' middleware is called before this middleware.`)
         );
-        expect(logger.debugRequest).toHaveBeenCalledWith(req, expect.stringContaining("OPEN request with requestId=\"UNKNOWN\""));
-        expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining("CLOSED request with requestId=\"UNKNOWN\""));
+        expect(logger.raw.debugRequest).toHaveBeenCalledWith(req, expect.stringContaining("OPEN request with requestId=\"UNKNOWN\""));
+        expect(logger.raw.debug).toHaveBeenCalledWith(expect.stringContaining("CLOSED request with requestId=\"UNKNOWN\""));
         expect(next).toHaveBeenCalled();
     });
 });

--- a/test/routers/handlers/personal-code/personalCode.unit.ts
+++ b/test/routers/handlers/personal-code/personalCode.unit.ts
@@ -410,7 +410,7 @@ describe("Personal code handler", () => {
         });
 
         it("Should redirect to the internal server error page when a server error response occurs", async () => {
-            jest.spyOn(logger, "error").mockImplementation(() => {});
+            jest.spyOn(logger, "debug").mockImplementation(() => {});
 
             const req = httpMocks.createRequest({
                 method: "POST",
@@ -447,7 +447,7 @@ describe("Personal code handler", () => {
 
             expect(viewData.errors).toBe("Processed Internal Server Error");
             expect(processHandlerException).toHaveBeenCalledWith(expect.objectContaining({ message: "Internal Server Error" }));
-            expect(logger.error).toHaveBeenCalled();
+            expect(logger.debug).toHaveBeenCalled();
 
         });
 

--- a/test/services/companyProfileService.unit.ts
+++ b/test/services/companyProfileService.unit.ts
@@ -42,7 +42,7 @@ describe("CompanyProfileService", () => {
             const request = {} as Request;
 
             await expect(getCompanyProfile(request, COMPANY_NUMBER)).rejects.toThrow(
-                new Error(`getCompanyProfile -HTTP status code 500 - Failed to get company profile for company number ${COMPANY_NUMBER}`)
+                new Error(`HTTP status code 500 - Failed to get company profile for companyNumber="${COMPANY_NUMBER}"`)
             );
         });
 
@@ -52,7 +52,7 @@ describe("CompanyProfileService", () => {
             const request = {} as Request;
 
             await expect(getCompanyProfile(request, COMPANY_NUMBER)).rejects.toThrow(
-                new Error(`getCompanyProfile -HTTP status code 400 - Failed to get company profile for company number ${COMPANY_NUMBER}`)
+                new Error(`HTTP status code 400 - Failed to get company profile for companyNumber="${COMPANY_NUMBER}"`)
             );
         });
 
@@ -62,7 +62,7 @@ describe("CompanyProfileService", () => {
             const request = {} as Request;
 
             await expect(getCompanyProfile(request, COMPANY_NUMBER)).rejects.toThrow(
-                new Error(`getCompanyProfile - Company Profile API returned no response for company number ${COMPANY_NUMBER}`)
+                new Error(`Company Profile API returned no response for companyNumber="${COMPANY_NUMBER}"`)
             );
         });
 
@@ -72,7 +72,7 @@ describe("CompanyProfileService", () => {
             const request = {} as Request;
 
             await expect(getCompanyProfile(request, COMPANY_NUMBER)).rejects.toThrow(
-                new Error(`getCompanyProfile - Company Profile API returned no resource for company number ${COMPANY_NUMBER}`)
+                new Error(`Company Profile API returned no resource for companyNumber="${COMPANY_NUMBER}"`)
             );
         });
     });

--- a/test/services/companyPscService.unit.ts
+++ b/test/services/companyPscService.unit.ts
@@ -72,7 +72,7 @@ describe("companyPscService", () => {
             const response = await getCompanyPscList(request, COMPANY_NUMBER);
             throw new Error("invalid expecting getCompanyPscList to throw error");
         } catch (error: any) {
-            expect(error.message).toBe("getCompanyPscList - Failed to get company psc list for company number 12345678 with start index 0 and items per page 100");
+            expect(error.message).toBe("Failed to get company psc list for companyNumber=\"12345678\" with start index 0 and items per page 100");
         }
     });
 

--- a/test/services/pscService.unit.ts
+++ b/test/services/pscService.unit.ts
@@ -53,7 +53,7 @@ describe("PSC Service", () => {
                 await getPscIndividual(COMPANY_NUMBER, PSC_ID);
                 throw new Error("invalid expecting getPscIndividual to throw error");
             } catch (error: any) {
-                expect(error.message).toBe("getPscIndividual -  Failed to get PSC with verification state for companyNumber: 12345678 and PSC notification ID: 67edfE436y35hetsie6zuAZtr");
+                expect(error.message).toBe("Failed to get PSC with verification state for companyNumber=\"12345678\", notificationId=\"67edfE436y35hetsie6zuAZtr\"");
             }
         });
 
@@ -66,14 +66,14 @@ describe("PSC Service", () => {
             mockGetPscIndividual.mockResolvedValueOnce(mockGet);
 
             await expect(getPscIndividual(COMPANY_NUMBER, PSC_NOTIFICATION_ID)).rejects.toThrow(
-                new Error(`getPscIndividual - no PSC with verification state returned for companyNumber: ${COMPANY_NUMBER} and PSC notification ID: ${PSC_NOTIFICATION_ID}`));
+                new Error(`no PSC with verification state returned for companyNumber="${COMPANY_NUMBER}", notificationId="${PSC_NOTIFICATION_ID}"`));
         });
 
         it("should throw an Error when there is no response", async () => {
             mockGetPscIndividual.mockResolvedValueOnce(undefined);
 
             await expect(getPscIndividual(COMPANY_NUMBER, PSC_NOTIFICATION_ID)).rejects.toThrow(
-                new Error(`getPscIndividual -  Failed to get PSC with verification state for companyNumber: ${COMPANY_NUMBER} and PSC notification ID: ${PSC_NOTIFICATION_ID}`));
+                new Error(`Failed to get PSC with verification state for companyNumber="${COMPANY_NUMBER}", notificationId="${PSC_NOTIFICATION_ID}"`));
         });
 
         it("should throw an Error when the API resource is missing", async () => {
@@ -84,7 +84,7 @@ describe("PSC Service", () => {
             mockGetPscIndividual.mockResolvedValueOnce(mockGet);
 
             await expect(getPscIndividual(COMPANY_NUMBER, PSC_NOTIFICATION_ID)).rejects.toThrow(
-                new Error(`getPscIndividual -  Failed to get PSC with verification state for companyNumber: ${COMPANY_NUMBER} and PSC notification ID: ${PSC_NOTIFICATION_ID}`));
+                new Error(`Failed to get PSC with verification state for companyNumber="${COMPANY_NUMBER}", notificationId="${PSC_NOTIFICATION_ID}"`));
         });
 
     });

--- a/test/services/pscVerificationService.unit.ts
+++ b/test/services/pscVerificationService.unit.ts
@@ -78,7 +78,7 @@ describe("pscVerificationService", () => {
 
             const response = await createPscVerification(req, CREATED_PSC_TRANSACTION, INITIAL_PSC_DATA).catch((error) => {
                 expect(error).toBeInstanceOf(Error);
-                expect(error).toHaveProperty("message", `createPscVerification - PSC Verification API POST request returned no resource for transaction ${TRANSACTION_ID}`);
+                expect(error).toHaveProperty("message", `PSC Verification API POST request returned no resource for transactionId="${TRANSACTION_ID}"`);
             });
             expect(response).toBeUndefined();
         });
@@ -86,7 +86,7 @@ describe("pscVerificationService", () => {
         it("should throw an error when PscVerification is undefined", async () => {
             const response = await createPscVerification(req, CREATED_PSC_TRANSACTION, undefined as any).catch((error) => {
                 expect(error).toBeInstanceOf(Error);
-                expect(error).toHaveProperty("message", `createPscVerification - Aborting: PscVerificationData is required for PSC Verification POST request for transaction ${TRANSACTION_ID}`);
+                expect(error).toHaveProperty("message", `Aborting: PscVerificationData is required for PSC Verification POST request for transactionId="${TRANSACTION_ID}"`);
             });
             expect(response).toBeUndefined();
         });
@@ -97,7 +97,7 @@ describe("pscVerificationService", () => {
 
             const response = await createPscVerification(req, CREATED_PSC_TRANSACTION, incompleteData as any).catch((error) => {
                 expect(error).toBeInstanceOf(Error);
-                expect(error).toHaveProperty("message", `createPscVerification - Aborting: companyNumber is required for PSC Verification POST request for transaction ${TRANSACTION_ID}.`);
+                expect(error).toHaveProperty("message", `Aborting: companyNumber is required for PSC Verification POST request for transactionId="${TRANSACTION_ID}"`);
             });
             expect(response).toBeUndefined();
         });
@@ -107,7 +107,7 @@ describe("pscVerificationService", () => {
 
             const response = await createPscVerification(req, CREATED_PSC_TRANSACTION, INITIAL_PSC_DATA).catch((error) => {
                 expect(error).toBeInstanceOf(Error);
-                expect(error).toHaveProperty("message", `createPscVerification - PSC Verification POST request returned no response for transaction ${TRANSACTION_ID}`);
+                expect(error).toHaveProperty("message", `PSC Verification POST request returned no response for transactionId="${TRANSACTION_ID}"`);
             });
             expect(response).toBeUndefined();
         });
@@ -117,7 +117,7 @@ describe("pscVerificationService", () => {
 
             const response = await createPscVerification(req, CREATED_PSC_TRANSACTION, INITIAL_PSC_DATA).catch((error) => {
                 expect(error).toBeInstanceOf(Error);
-                expect(error).toHaveProperty("message", `createPscVerification - HTTP status code is undefined - Failed to POST PSC Verification for transaction ${TRANSACTION_ID}`);
+                expect(error).toHaveProperty("message", `HTTP status code is undefined - Failed to POST PSC Verification for transactionId="${TRANSACTION_ID}"`);
             });
             expect(response).toBeUndefined();
         });
@@ -131,7 +131,7 @@ describe("pscVerificationService", () => {
             const response = await createPscVerification(req, CREATED_PSC_TRANSACTION, INITIAL_PSC_DATA).catch((error) => {
                 expect(error).toBeInstanceOf(DataIntegrityError);
                 expect(error).toHaveProperty("type", "PSC_DATA");
-                expect(error).toHaveProperty("message", `createPscVerification received ${status} - Failed to POST PSC Verification for transaction ${TRANSACTION_ID}`);
+                expect(error).toHaveProperty("message", `received ${status} - Failed to POST PSC Verification for transactionId="${TRANSACTION_ID}"`);
             });
             expect(response).toBeUndefined();
         });
@@ -151,7 +151,7 @@ describe("pscVerificationService", () => {
             const response = await createPscVerification(req, CREATED_PSC_TRANSACTION, INITIAL_PSC_DATA).catch((error) => {
                 expect(error).toBeInstanceOf(DataIntegrityError);
                 expect(error).toHaveProperty("type", "PSC_DATA");
-                expect(error).toHaveProperty("message", `createPscVerification received ${status} - ${errorMessage}`);
+                expect(error).toHaveProperty("message", `received ${status} - ${errorMessage}`);
             });
             expect(response).toBeUndefined();
         });
@@ -165,7 +165,7 @@ describe("pscVerificationService", () => {
             const response = await createPscVerification(req, CREATED_PSC_TRANSACTION, INITIAL_PSC_DATA).catch((error) => {
                 expect(error).toBeInstanceOf(HttpError);
                 expect(error).toHaveProperty("status", HttpStatusCode.ServiceUnavailable);
-                expect(error).toHaveProperty("message", `createPscVerification - Failed to POST PSC Verification for transaction ${TRANSACTION_ID}`);
+                expect(error).toHaveProperty("message", `Failed to POST PSC Verification for transactionId="${TRANSACTION_ID}"`);
             });
             expect(response).toBeUndefined();
         });
@@ -177,7 +177,7 @@ describe("pscVerificationService", () => {
 
             const response = await createPscVerification(req, CREATED_PSC_TRANSACTION, incompleteData).catch((error) => {
                 expect(error).toBeInstanceOf(DataIntegrityError);
-                expect(error).toHaveProperty("message", `createPscVerification - Aborting: pscNotificationId is required for PSC Verification POST request for transaction ${TRANSACTION_ID}.`);
+                expect(error).toHaveProperty("message", `Aborting: pscNotificationId is required for PSC Verification POST request for transactionId="${TRANSACTION_ID}"`);
             });
             expect(response).toBeUndefined();
         });
@@ -209,7 +209,7 @@ describe("pscVerificationService", () => {
             const response = await createPscVerification(req, CREATED_PSC_TRANSACTION, INITIAL_PSC_DATA).catch((error) => {
                 expect(error).toBeInstanceOf(DataIntegrityError);
                 expect(error).toHaveProperty("type", "PSC_DATA");
-                expect(error).toHaveProperty("message", `createPscVerification - We are currently unable to process a Verification filing for this PSC - Failed to POST PSC Verification for transaction ${TRANSACTION_ID}`);
+                expect(error).toHaveProperty("message", `We are currently unable to process a Verification filing for this PSC - Failed to POST PSC Verification for transactionId="${TRANSACTION_ID}"`);
             });
 
             expect(response).toBeUndefined();
@@ -242,7 +242,7 @@ describe("pscVerificationService", () => {
                 httpStatusCode: HttpStatusCode.Unauthorized
             };
             mockGetPscVerification.mockResolvedValueOnce(mockGet);
-            const expectedMessage = `getPscVerification - User not authorized owner for transaction ${TRANSACTION_ID}, pscVerification ${PSC_VERIFICATION_ID}`;
+            const expectedMessage = `User not authorized owner for transactionId="${TRANSACTION_ID}", pscVerificationId="${PSC_VERIFICATION_ID}"`;
 
             await expect(getPscVerification(req, TRANSACTION_ID, PSC_VERIFICATION_ID)).rejects.toThrow(new HttpError(expectedMessage, HttpStatusCode.NotFound));
         });
@@ -253,9 +253,11 @@ describe("pscVerificationService", () => {
                 httpStatusCode: undefined
             };
             mockGetPscVerification.mockResolvedValueOnce(mockGet);
-            const expectedMessage = `getPscVerification - HTTP status code is undefined - Failed to GET PSC Verification for transaction ${TRANSACTION_ID}, pscVerification ${PSC_VERIFICATION_ID}`;
+            const expectedMessage = `HTTP status code is undefined - Failed to GET PSC Verification for transactionId="${TRANSACTION_ID}", pscVerificationId="${PSC_VERIFICATION_ID}"`;
 
-            await expect(getPscVerification(req, TRANSACTION_ID, PSC_VERIFICATION_ID)).rejects.toThrow(new Error(expectedMessage));
+            await expect(getPscVerification(req, TRANSACTION_ID, PSC_VERIFICATION_ID)).rejects.toThrow(
+                new Error(expectedMessage)
+            );
         });
 
         it("should throw an error when the response resource is undefined", async () => {
@@ -266,14 +268,14 @@ describe("pscVerificationService", () => {
             mockGetPscVerification.mockResolvedValueOnce(mockGet);
 
             await expect(getPscVerification(req, TRANSACTION_ID, PSC_VERIFICATION_ID)).rejects.toThrow(
-                new Error(`getPscVerification - PSC Verification API GET request returned no resource for transaction ${TRANSACTION_ID}, pscVerification ${PSC_VERIFICATION_ID}`));
+                new Error(`PSC Verification API GET request returned no resource for transactionId="${TRANSACTION_ID}", pscVerificationId="${PSC_VERIFICATION_ID}"`));
         });
 
         it("should throw an Error when no response from API", async () => {
             mockGetPscVerification.mockResolvedValueOnce(undefined);
 
             await expect(getPscVerification(req, TRANSACTION_ID, PSC_VERIFICATION_ID)).rejects.toThrow(
-                new Error(`getPscVerification - PSC Verification GET request returned no response for transaction ${TRANSACTION_ID}, pscVerification ${PSC_VERIFICATION_ID}`));
+                new Error(`PSC Verification GET request returned no response for transactionId="${TRANSACTION_ID}", pscVerificationId="${PSC_VERIFICATION_ID}"`));
         });
 
         it("should throw an Error when API status is unavailable", async () => {
@@ -283,7 +285,7 @@ describe("pscVerificationService", () => {
             mockGetPscVerification.mockResolvedValueOnce(mockGet);
 
             await expect(getPscVerification(req, TRANSACTION_ID, PSC_VERIFICATION_ID)).rejects.toThrow(
-                new HttpError(`getPscVerification - Failed to GET PSC Verification for transaction ${TRANSACTION_ID}, pscVerification ${PSC_VERIFICATION_ID}`, HttpStatusCode.ServiceUnavailable));
+                new HttpError(`Failed to GET PSC Verification for transactionId="${TRANSACTION_ID}", pscVerificationId="${PSC_VERIFICATION_ID}"`, HttpStatusCode.ServiceUnavailable));
         });
     });
 
@@ -310,7 +312,7 @@ describe("pscVerificationService", () => {
 
             const response = await patchPscVerification(req, TRANSACTION_ID, PSC_VERIFICATION_ID, PATCH_INDIVIDUAL_DATA).catch((error) => {
                 expect(error).toBeInstanceOf(Error);
-                expect(error).toHaveProperty("message", `patchPscVerification - PSC Verification PATCH request returned no response for resource with transactionId ${TRANSACTION_ID}, pscVerificationId ${PSC_VERIFICATION_ID}`);
+                expect(error).toHaveProperty("message", `PSC Verification PATCH request returned no response for resource with transactionId="${TRANSACTION_ID}", pscVerificationId="${PSC_VERIFICATION_ID}"`);
             });
             expect(response).toBeUndefined();
         });
@@ -320,7 +322,7 @@ describe("pscVerificationService", () => {
 
             const response = await patchPscVerification(req, TRANSACTION_ID, PSC_VERIFICATION_ID, PATCH_INDIVIDUAL_DATA).catch((error) => {
                 expect(error).toBeInstanceOf(Error);
-                expect(error).toHaveProperty("message", `patchPscVerification - HTTP status code is undefined - Failed to PATCH PSC Verification for resource with transactionId ${TRANSACTION_ID}, pscVerificationId ${PSC_VERIFICATION_ID}`);
+                expect(error).toHaveProperty("message", `HTTP status code is undefined - Failed to PATCH PSC Verification for resource with transactionId="${TRANSACTION_ID}", pscVerificationId="${PSC_VERIFICATION_ID}"`);
             });
             expect(response).toBeUndefined();
         });
@@ -334,7 +336,10 @@ describe("pscVerificationService", () => {
             const response = await patchPscVerification(req, TRANSACTION_ID, PSC_VERIFICATION_ID, PATCH_INDIVIDUAL_DATA).catch((error) => {
                 expect(error).toBeInstanceOf(DataIntegrityError);
                 expect(error).toHaveProperty("type", "PSC_DATA");
-                expect(error).toHaveProperty("message", `patchPscVerification received ${status} - Failed to PATCH PSC Verification for resource with transactionId ${TRANSACTION_ID}, pscVerificationId ${PSC_VERIFICATION_ID}`);
+                expect(error).toHaveProperty(
+                    "message",
+                    `received ${status} - Failed to PATCH PSC Verification for resource with transactionId="${TRANSACTION_ID}", pscVerificationId="${PSC_VERIFICATION_ID}", context: \n{}`
+                );
             });
             expect(response).toBeUndefined();
         });
@@ -354,7 +359,7 @@ describe("pscVerificationService", () => {
             const response = await patchPscVerification(req, TRANSACTION_ID, PSC_VERIFICATION_ID, PATCH_INDIVIDUAL_DATA).catch((error) => {
                 expect(error).toBeInstanceOf(DataIntegrityError);
                 expect(error).toHaveProperty("type", "PSC_DATA");
-                expect(error).toHaveProperty("message", `patchPscVerification received ${status} - ${errorMessage}`);
+                expect(error).toHaveProperty("message", `received ${status} - ${errorMessage}, context: \n{}`);
             });
             expect(response).toBeUndefined();
         });
@@ -368,7 +373,7 @@ describe("pscVerificationService", () => {
             const response = await patchPscVerification(req, TRANSACTION_ID, PSC_VERIFICATION_ID, PATCH_INDIVIDUAL_DATA).catch((error) => {
                 expect(error).toBeInstanceOf(HttpError);
                 expect(error).toHaveProperty("status", HttpStatusCode.ServiceUnavailable);
-                expect(error).toHaveProperty("message", `patchPscVerification - Failed to PATCH PSC Verification for resource with transactionId ${TRANSACTION_ID}, pscVerificationId ${PSC_VERIFICATION_ID}`);
+                expect(error).toHaveProperty("message", `Failed to PATCH PSC Verification for resource with transactionId="${TRANSACTION_ID}", pscVerificationId="${PSC_VERIFICATION_ID}"`);
             });
             expect(response).toBeUndefined();
         });
@@ -381,7 +386,7 @@ describe("pscVerificationService", () => {
             mockPatchPscVerification.mockResolvedValueOnce(mockPatch);
 
             await expect(patchPscVerification(req, TRANSACTION_ID, PSC_VERIFICATION_ID, PATCH_INDIVIDUAL_DATA)).rejects.toThrow(
-                new Error(`PSC Verification API PATCH request returned no resource with transactionId ${TRANSACTION_ID}, pscVerificationId ${PSC_VERIFICATION_ID}`));
+                new Error(`PSC Verification API PATCH request returned no resource with transactionId="${TRANSACTION_ID}", pscVerificationId="${PSC_VERIFICATION_ID}"`));
 
         });
     });
@@ -408,7 +413,7 @@ describe("pscVerificationService", () => {
             mockCheckPlannedMaintenance.mockResolvedValueOnce(undefined);
 
             await expect(checkPlannedMaintenance(req)).rejects.toThrow(
-                new Error("checkPlannedMaintenance - PSC Verification GET maintenance request returned no response"));
+                new Error("PSC Verification GET maintenance request returned no response"));
         });
 
         it("should throw an Error when API status is unavailable", async () => {
@@ -418,7 +423,7 @@ describe("pscVerificationService", () => {
             mockCheckPlannedMaintenance.mockResolvedValueOnce(mockPlannedMaintenance);
 
             await expect(checkPlannedMaintenance(req)).rejects.toThrow(
-                new Error("checkPlannedMaintenance - HTTP status code 503 - Failed to GET Planned Maintenance response"));
+                new Error("HTTP status code 503 - Failed to GET Planned Maintenance response"));
         });
 
         it("should throw an error when the API call returns a non-OK HTTP status code", async () => {
@@ -429,7 +434,7 @@ describe("pscVerificationService", () => {
             mockCheckPlannedMaintenance.mockResolvedValue(mockErrorResponse);
 
             await expect(checkPlannedMaintenance(req)).rejects.toThrow(
-                "checkPlannedMaintenance - HTTP status code 500 - Failed to GET Planned Maintenance response"
+                "HTTP status code 500 - Failed to GET Planned Maintenance response"
             );
         });
 
@@ -441,7 +446,7 @@ describe("pscVerificationService", () => {
             mockCheckPlannedMaintenance.mockResolvedValue(mockErrorResponse);
 
             await expect(checkPlannedMaintenance(req)).rejects.toThrow(
-                "checkPlannedMaintenance - HTTP status code undefined - Failed to GET Planned Maintenance response"
+                "HTTP status code undefined - Failed to GET Planned Maintenance response"
             );
         });
 
@@ -518,20 +523,20 @@ describe("pscVerificationService", () => {
 
             mockGetValidationStatus.mockResolvedValueOnce(errorResponse);
 
-            await expect(getValidationStatus(req, TRANSACTION_ID, PSC_VERIFICATION_ID)).rejects.toThrowErrorMatchingInlineSnapshot(
-                `"getValidationStatus - Error getting validation status: HTTP response is: 404 for transaction ${TRANSACTION_ID}, pscVerification ${PSC_VERIFICATION_ID}"`);
+            await expect(getValidationStatus(req, TRANSACTION_ID, PSC_VERIFICATION_ID)).rejects.toThrow(
+                `Error getting validation status: HTTP response is 404 for transactionId="11111-22222-33333", pscVerificationId="662a0de6a2c6f9aead0f32ab"`
+            );
 
             expect(mockCreateOAuthApiClient).toHaveBeenCalledTimes(1);
             expect(mockGetValidationStatus).toHaveBeenCalledTimes(1);
             expect(mockGetValidationStatus).toHaveBeenCalledWith(TRANSACTION_ID, PSC_VERIFICATION_ID);
-
         });
 
         it("should throw an error when the response is null", async () => {
             mockGetValidationStatus.mockResolvedValueOnce(null);
 
-            await expect(getValidationStatus(req, TRANSACTION_ID, PSC_VERIFICATION_ID)).rejects.toThrowErrorMatchingInlineSnapshot(
-                `"getValidationStatus - PSC Verification GET validation status request did not return a response for transaction ${TRANSACTION_ID}, pscVerification ${PSC_VERIFICATION_ID}"`
+            await expect(getValidationStatus(req, TRANSACTION_ID, PSC_VERIFICATION_ID)).rejects.toThrow(
+                `PSC Verification GET validation status request did not return a response for transactionId="${TRANSACTION_ID}", pscVerificationId="${PSC_VERIFICATION_ID}"`
             );
 
             expect(mockCreateOAuthApiClient).toHaveBeenCalledTimes(1);
@@ -547,14 +552,13 @@ describe("pscVerificationService", () => {
 
             mockGetValidationStatus.mockResolvedValueOnce(mockValidationStatus);
 
-            await expect(getValidationStatus(req, TRANSACTION_ID, PSC_VERIFICATION_ID)).rejects.toThrowErrorMatchingInlineSnapshot(
-                `"getValidationStatus - Error getting validation status for transaction ${TRANSACTION_ID}, pscVerification ${PSC_VERIFICATION_ID}"`
+            await expect(getValidationStatus(req, TRANSACTION_ID, PSC_VERIFICATION_ID)).rejects.toThrow(
+                `Error getting validation status for transactionId="${TRANSACTION_ID}", pscVerificationId="${PSC_VERIFICATION_ID}"`
             );
 
             expect(mockCreateOAuthApiClient).toHaveBeenCalledTimes(1);
             expect(mockGetValidationStatus).toHaveBeenCalledTimes(1);
             expect(mockGetValidationStatus).toHaveBeenCalledWith(TRANSACTION_ID, PSC_VERIFICATION_ID);
-
         });
     });
 });

--- a/test/services/transactionService.unit.ts
+++ b/test/services/transactionService.unit.ts
@@ -69,7 +69,9 @@ describe("Transaction service", () => {
             };
             mockGetTransaction.mockResolvedValueOnce(mockResponse);
 
-            await expect(getTransaction(req, TRANSACTION_ID)).rejects.toThrow(new HttpError("Failed to get transaction", HttpStatusCode.BadRequest));
+            await expect(getTransaction(req, TRANSACTION_ID)).rejects.toThrow(
+                new HttpError(`Failed to get transaction with transactionId="${TRANSACTION_ID}"`, HttpStatusCode.BadRequest)
+            );
             expect(mockGetTransaction).toHaveBeenCalledWith(TRANSACTION_ID);
         });
 


### PR DESCRIPTION
Jira ticket: https://companieshouse.atlassian.net/browse/IDVA3-3088

See [logging.md](https://github.com/companieshouse/psc-verification-web/blob/feature/production-ready-logging/docs/logging.md) for documentation.

- Replaced all instances of `createAndLogError` with `throw Error` (implicit logging).
- Removed all client information from logs.
- Removed raw SDK response logging.
- Downgraded validation errors to debug.
- Introduced a transparent wrapper over `ApplicationLogger` that automatically figures out the calling class, method, and file.
- Introduced a new docs/ directory for Markdown documentation + documented [logging](https://github.com/companieshouse/psc-verification-web/blob/feature/production-ready-logging/docs/logging.md).

Note that some log lines, such as ones from the session middlware & healthcheck, won't conform to the new logging standard since they come from external repos.