### PR TITLE
IDVA3-3094 Handle error scenario for closing a transaction

### DIFF
--- a/src/middleware/error-interceptors/httpErrorInterceptor.ts
+++ b/src/middleware/error-interceptors/httpErrorInterceptor.ts
@@ -30,7 +30,7 @@ export const httpErrorInterceptor = (error: HttpError | Error, req: Request, res
         res.status(error.status);
     } else {
         // Treat generic errors as an internal server error
-        logger.raw.error(`${logger.getPrefix({ error })} Unhandled error at URL: ${req.url}. ${error.stack}`);
+        logger.raw.error(`${logger.getPrefix({ error })} Generic error at URL: ${req.url}. ${error.stack}`);
         res.status(HttpStatusCode.InternalServerError);
     }
 

--- a/src/routers/handlers/psc-verified/pscVerifiedHandler.ts
+++ b/src/routers/handlers/psc-verified/pscVerifiedHandler.ts
@@ -59,8 +59,8 @@ export class PscVerifiedHandler extends GenericHandler<PscVerifiedViewData> {
                 logger.info(`transaction closed successfully for transactionId="${req.params?.transactionId}", submissionId="${req.params?.submissionId}"`);
             })
             .catch((err) => {
-                // TODO: handle failure properly (redirect to Error Screen? TBC)
-                logger.error(`error closing transaction for transactionId="${req.params?.transactionId}", submissionId="${req.params?.submissionId}": ${err.message}`);
+                const message = err.message ? `: ${err.message}` : "";
+                throw new Error(`failed to close transaction for transactionId="${req.params?.transactionId}", submissionId="${req.params?.submissionId}"${message}`);
             });
 
         return {

--- a/test/routers/handlers/psc-verified/pscVerifiedHandler.unit.ts
+++ b/test/routers/handlers/psc-verified/pscVerifiedHandler.unit.ts
@@ -82,14 +82,15 @@ describe("PSC Verified handler", () => {
             expect(mockCloseTransaction).toHaveBeenCalledWith(request, TRANSACTION_ID, PSC_VERIFICATION_ID);
         });
 
-        it("Should throw an error when closeTransaction fails", async () => {
-            const errorMessage = "Transaction close failed";
-            mockCloseTransaction.mockRejectedValueOnce(new Error(errorMessage));
+        it.each([undefined, "something went wrong"])("Should throw an error when closeTransaction fails", async (message) => {
+            mockCloseTransaction.mockRejectedValueOnce(new Error(message));
             const handler = new PscVerifiedHandler();
 
-            await expect(handler.executeGet(request, response)).rejects.toThrow(
-                `failed to close transaction for transactionId="${TRANSACTION_ID}", submissionId="${PSC_VERIFICATION_ID}": ${errorMessage}`
-            );
+            const expectedError = message
+                ? `failed to close transaction for transactionId="${TRANSACTION_ID}", submissionId="${PSC_VERIFICATION_ID}": ${message}`
+                : `failed to close transaction for transactionId="${TRANSACTION_ID}", submissionId="${PSC_VERIFICATION_ID}"`;
+
+            await expect(handler.executeGet(request, response)).rejects.toThrow(expectedError);
 
             expect(mockGetPscIndividual).toHaveBeenCalledTimes(1);
             expect(mockCloseTransaction).toHaveBeenCalledTimes(1);

--- a/test/routers/handlers/psc-verified/pscVerifiedHandler.unit.ts
+++ b/test/routers/handlers/psc-verified/pscVerifiedHandler.unit.ts
@@ -40,10 +40,11 @@ describe("PSC Verified handler", () => {
     });
 
     describe("executeGet", () => {
+        let request: any;
+        let response: any;
 
-        it("Should close the transaction and resolve correct view data", async () => {
-            mockCloseTransaction.mockResolvedValueOnce(undefined);
-            const request = httpMocks.createRequest({
+        beforeEach(() => {
+            request = httpMocks.createRequest({
                 method: "GET",
                 url: Urls.PSC_VERIFIED,
                 params: {
@@ -54,7 +55,11 @@ describe("PSC Verified handler", () => {
                     pscType: "individual"
                 }
             });
-            const response = httpMocks.createResponse({ locals: { submission: INDIVIDUAL_VERIFICATION_FULL, companyProfile: validCompanyProfile } });
+            response = httpMocks.createResponse({ locals: { submission: INDIVIDUAL_VERIFICATION_FULL, companyProfile: validCompanyProfile } });
+        });
+
+        it("Should close the transaction and resolve correct view data", async () => {
+            mockCloseTransaction.mockResolvedValueOnce(undefined);
             const handler = new PscVerifiedHandler();
             const expectedPrefix = `/persons-with-significant-control-verification/transaction/${TRANSACTION_ID}/submission/${PSC_VERIFICATION_ID}`;
 
@@ -75,7 +80,19 @@ describe("PSC Verified handler", () => {
             expect(mockGetPscIndividual).toHaveBeenCalledWith(COMPANY_NUMBER, PSC_NOTIFICATION_ID);
             expect(mockCloseTransaction).toHaveBeenCalledTimes(1);
             expect(mockCloseTransaction).toHaveBeenCalledWith(request, TRANSACTION_ID, PSC_VERIFICATION_ID);
+        });
 
+        it("Should throw an error when closeTransaction fails", async () => {
+            const errorMessage = "Transaction close failed";
+            mockCloseTransaction.mockRejectedValueOnce(new Error(errorMessage));
+            const handler = new PscVerifiedHandler();
+
+            await expect(handler.executeGet(request, response)).rejects.toThrow(
+                `failed to close transaction for transactionId="${TRANSACTION_ID}", submissionId="${PSC_VERIFICATION_ID}": ${errorMessage}`
+            );
+
+            expect(mockGetPscIndividual).toHaveBeenCalledTimes(1);
+            expect(mockCloseTransaction).toHaveBeenCalledTimes(1);
         });
     });
 });


### PR DESCRIPTION
**Jira ticket**: [IDVA3-3094](https://companieshouse.atlassian.net/browse/IDVA3-3094)

## Brief description of the changes
Previously we had just logged an error if the `closeTransaction` call failed for any reason. This PR introduces an error that will be presented to the user as a 500 internal server error.

## Working example
>
> Use screenshots or logs to show what your changes do.

```logs
2025-06-11T10:30:26.732+00:00 error: pscVerifiedHandler - Generic error at URL: /persons-with-significant-control-verification/transaction/001932-836617-496377/submission/68495a92d70d7051e822af48/psc-verified?companyNumber=00006400&lang=en. Error: failed to close transaction for transactionId="001932-836617-49637766", submissionId="68495a92d70d7051e822af48"
    at /app/src/routers/handlers/psc-verified/pscVerifiedHandler.ts:63:23
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at PscVerifiedHandler.executeGet (/app/src/routers/handlers/psc-verified/pscVerifiedHandler.ts:57:9)
    at /app/src/routers/pscVerifiedRouter.ts:8:40
    at /app/src/utils/asyncHandler.ts:14:13
  -> created: 2025-06-11T10:30:26.732+00:00
  -> event: error
  -> namespace: psc-verification-web
2025-06-11T10:30:26.734+00:00 info: httpErrorInterceptor - Rendering template: 500-internal-server-error for status code 500
  -> created: 2025-06-11T10:30:26.734+00:00
  -> event: info
  -> namespace: psc-verification-web
```

See video [here](https://companieshouse.atlassian.net/browse/IDVA3-3094?focusedCommentId=297555).

## Test notes
>
> Add test notes only if they're **not** already included in the Jira ticket.

Included in Jira ticket.

## Checklist

- [x] Adhered to the [coding style guidelines](https://companieshouse.atlassian.net/wiki/spaces/DEV/pages/4290084946/Coding+Standards+and+Styleguides).
- [x] Added/updated logging appropriately.
- [x] Written tests.
- [ ] ~~Updated Docker/ECS configs.~~
- [ ] ~~Added all new properties to chs-configs.~~
- [x] Updated release notes.

Strikethrough (`~~like this~~`) anything not applicable to your changes.


[IDVA3-3094]: https://companieshouse.atlassian.net/browse/IDVA3-3094?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ