### PR TITLE
Welsh text for personal code screen

### DIFF
--- a/locales/cy/errors.json
+++ b/locales/cy/errors.json
@@ -1,6 +1,4 @@
 {
-    "server_error_summary": "To be translated: server_error_summary",
-    "error_summary_title": "To be translated: error_summary_title",
-    "default_error_summary": "To be translated: default_error_summary",
-    "default_error_inline": "To be translated: default_error_inline"
+    "server_error_summary": "Roedd gwall wrth brosesu\u0027r cais.",
+    "error_summary_title": "Mae yna broblem"
 }

--- a/locales/cy/personal-code.json
+++ b/locales/cy/personal-code.json
@@ -1,9 +1,9 @@
 {
-  "personal_code_title": "To be translated: personal_code_title",
-  "personal_code_details_summaryText": "To be translated: personal_code_details_summaryText",
-  "personal_code_details_text": "To be translated: personal_code_details_text",
-  "personal_code_born": "To be translated: personal_code_born",
-  "personal_code_button": "To be translated: personal_code_button",
-  "personal_code_error_summary": "To be translated: personal_code_error_summary",
-  "personal_code_error_inline": "To be translated: personal_code_error_inline"
+  "personal_code_title": "Beth yw eu cod personol T\u0177 Cwmn\u00efau?",
+  "personal_code_details_summaryText": "Ble i ddod o hyd i god personol T\u0177\u0027r Cwmn\u00efau",
+  "personal_code_details_text": "Mae hwn yn god 11 nod sy\u0027n cael ei roi i berson ar \u00f4l iddynt gwblhau gwiriad hunaniaeth gyda Th\u0177\u0027r Cwmn\u00efau.",
+  "personal_code_born": "Ganwyd",
+  "personal_code_button": "Cadw a pharhau",
+  "personal_code_error_summary": "Cofnodwch god personol T\u0177\u0027r Cwmn\u00efau",
+  "personal_code_error_inline": "Cofnodwch god personol T\u0177\u0027r Cwmn\u00efau"
 }

--- a/locales/cy/start.json
+++ b/locales/cy/start.json
@@ -1,5 +1,5 @@
 {
-    "start_main_title": "To be translated: start_main_title",
+    "start_main_title": "Darparwch fanylion gwiriad hunaniaeth ar gyfer person \u2038 rheolaeth arwyddocaol (PRhA)",
     "start_service_description_1": "To be translated: start_service_description_1",
     "start_service_description_2": "To be translated: start_service_description_2",
     "start_personal_code_details_main_link": "To be translated: start_personal_code_details_main_link",

--- a/locales/en/errors.json
+++ b/locales/en/errors.json
@@ -1,6 +1,4 @@
 {
     "server_error_summary" : "There was an error processing the request.",
-    "error_summary_title" : "There is a problem",
-    "default_error_summary" : "Your request contains validation errors",
-    "default_error_inline" : "Your request contains validation errors"
+    "error_summary_title" : "There is a problem"
 }


### PR DESCRIPTION
**IDVA3-1108**

## Welsh language values for the UVID / personal code screen
- I've used unicode notation for the special welsh characters
- also includes additions for errors and main service title
- the 2 keys `default_error_summary` and `default_error_inline` - I don't see being used anywhere, so removed

## Working example
<img width="975" alt="Screenshot 2025-07-01 at 9 53 11 am" src="https://github.com/user-attachments/assets/31b9d615-c69e-4450-9140-2f6e103be122" />

## Checklist

- [x] Adhered to the [coding style guidelines](https://companieshouse.atlassian.net/wiki/spaces/DEV/pages/4290084946/Coding+Standards+and+Styleguides).
- [ ] Added/updated logging appropriately.
- [ ] Written tests.
- [x] Tested the new code in my local environment.
- [ ] Updated Docker/ECS configs.
- [ ] Added all new properties to chs-configs.
- [ ] Updated release notes.

Strikethrough (`~~like this~~`) anything not applicable to your changes.
