### PR TITLE
Replace the nav bar with the version in ch-node-utils

### DIFF
--- a/locales/cy/global.json
+++ b/locales/cy/global.json
@@ -6,5 +6,6 @@
     "global_save_continue_button": "Cadw a parhau",
     "global_continue_button": "Parhau",
     "global_back_link": "Yn ôl",
-    "global_sign_out_link": "Allgofnodi"
+    "global_sign_out_link": "Allgofnodi",
+    "global_manage_account_link": "Rheoli eich cyfrif"
 }

--- a/locales/en/global.json
+++ b/locales/en/global.json
@@ -6,5 +6,6 @@
     "global_save_continue_button": "Save and continue",
     "global_continue_button": "Continue",
     "global_back_link": "Back",
-    "global_sign_out_link": "Sign Out"
+    "global_sign_out_link": "Sign Out",
+    "global_manage_account_link": "Manage account"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8727,6 +8727,7 @@
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
             "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
             "optional": true,

--- a/src/app.ts
+++ b/src/app.ts
@@ -71,6 +71,7 @@ app.use(servicePathPrefix + urlWithTransactionIdAndSubmissionId, blockClosedTran
 // serve static files
 app.use(express.static(path.join(__dirname, "./../assets/public")));
 
+njk.addGlobal("accountUrl", process.env.ACCOUNT_URL);
 njk.addGlobal("cdnUrlCss", process.env.CDN_URL_CSS);
 njk.addGlobal("cdnUrlJs", process.env.CDN_URL_JS);
 njk.addGlobal("cdnHost", process.env.CDN_HOST);

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -3,6 +3,7 @@ import { Validators, addProtocolIfMissing, readEnv } from "./validator";
 const { str, url, bool, port } = Validators;
 
 export const env = readEnv(process.env, {
+    ACCOUNT_URL: str.describe("Host URL for the account service"),
     API_URL: str.describe("API base URL for service interaction"),
     APP_NAME: str.describe("Name of the application"),
     CACHE_SERVER: str.describe("Name of the server cache"),

--- a/src/views/layouts/default.njk
+++ b/src/views/layouts/default.njk
@@ -22,7 +22,7 @@
         {% set signOutHref = chsUrl + "/signout" %}
 
         {% set menuItems = [
-          { id: "your-details", href: userAccountHref , displayText: i18n.global_manage_account },
+          { id: "your-details", href: userAccountHref , displayText: i18n.global_manage_account_link },
           { id: "user-signout", href: signOutHref, displayText: i18n.global_sign_out_link }
         ] | reject("falsy") %}
 

--- a/src/views/layouts/default.njk
+++ b/src/views/layouts/default.njk
@@ -18,7 +18,7 @@
     <div class="govuk-width-container ">
       {% if isSignedIn %}
         {% set signInHref = chsUrl + "/signin" %}
-        {% set userAccountHref = accountUrl + "/user/account" %}
+        {% set userAccountHref = accountUrl + "/user/account?lang=" + lang %}
         {% set signOutHref = chsUrl + "/signout" %}
 
         {% set menuItems = [

--- a/src/views/layouts/default.njk
+++ b/src/views/layouts/default.njk
@@ -4,6 +4,7 @@
 {% import "add-lang-to-url.njk" as lang2url %}
 {% from "csrf-token-input/macro.njk" import csrfTokenInput %}
 {% include "partials/__meta_header.njk" %}
+{% from "navbar.njk" import addNavbar %}
 
   <body class="govuk-template__body" >
 
@@ -16,7 +17,16 @@
 
     <div class="govuk-width-container ">
       {% if isSignedIn %}
-        {% include "partials/signout-bar.njk" %}
+        {% set signInHref = chsUrl + "/signin" %}
+        {% set userAccountHref = accountUrl + "/user/account" %}
+        {% set signOutHref = chsUrl + "/signout" %}
+
+        {% set menuItems = [
+          { id: "your-details", href: userAccountHref , displayText: i18n.global_manage_account },
+          { id: "user-signout", href: signOutHref, displayText: i18n.global_sign_out_link }
+        ] | reject("falsy") %}
+
+        {{ addNavbar(signInHref, menuItems, userEmail, lang) }}
       {% endif %}
 
       {% if backURL %}

--- a/src/views/partials/__footer.njk
+++ b/src/views/partials/__footer.njk
@@ -48,6 +48,8 @@
     </p>
 </noscript>
 <script src="{{ cdnHost }}/javascripts/vendor/jquery-3.3.1.min.js"></script>
+<script src="{{ cdnHost }}/javascripts/lib/navbar.js"></script>
+<script src="{{ cdnHost }}/javascripts/app/session-timeout.js"></script>
 <!--<script src="/all.js"></script>
 <script>window.GOVUKFrontend.initAll()</script>-->
 

--- a/src/views/partials/__meta_header.njk
+++ b/src/views/partials/__meta_header.njk
@@ -7,6 +7,7 @@
     <link href="{{ cdnHost }}/stylesheets/govuk-frontend/v4.6.0/govuk-frontend-4.6.0.min.css" rel="stylesheet"/>
     <link href="{{ cdnHost }}/stylesheets/services/presenter-account/application.css" rel="stylesheet"/>
     <link href="{{ cdnHost }}/stylesheets/extensions/languages-nav.css" rel="stylesheet"/>
+    <link href="{{ cdnHost }}/stylesheets/ch.gov.uk.css" rel="stylesheet"/>
     <link href="{{ cdnUrlCss }}/app.min.css" media="all" rel="stylesheet" type="text/css" />
     <link href="{{ cdnHost }}/images/govuk-frontend/v4.6.0/images/favicon.ico" rel="icon" type="image/x-icon" />
     {% include "partials/__styles.njk" %}

--- a/src/views/partials/signout-bar.njk
+++ b/src/views/partials/signout-bar.njk
@@ -1,8 +1,0 @@
-{% if userEmail %}
-    {% set email = userEmail | default("Not signed in") %}
-    <div class="signout-bar" id="navigation">
-        <span class="content-email" id="signed-in-user">{{email}}</span>
-        <a class="govuk-link" href="{{ ExternalUrls.SIGNOUT }}" data-event-id="sign-out-button" id="user-signout">{{ i18n.global_sign_out_link }}</a>
-    </div>
-    <script src="{{ cdnHost }}/javascripts/app/session-timeout.js"></script>
-{% endif %}

--- a/test/global.setup.ts
+++ b/test/global.setup.ts
@@ -1,4 +1,5 @@
 export default () => {
+    process.env.ACCOUNT_URL = "http://account.chs.local";
     process.env.API_URL = "http://api.chs.local";
     process.env.APP_NAME = "psc-verification-web";
     process.env.CACHE_SERVER = "cache_server";


### PR DESCRIPTION
**Jira ticket**: IDVA3-2613

## Use Navbar from ch-node-utils library

## Working example
<img width="715" alt="Screenshot 2025-07-01 at 3 44 49 pm" src="https://github.com/user-attachments/assets/8cc25742-feff-4cf5-928a-fa26dfc11485" />
<img width="669" alt="Screenshot 2025-07-01 at 3 44 58 pm" src="https://github.com/user-attachments/assets/eae7d668-76c2-47ab-bd69-9e09825e92c7" />

Requires: https://github.com/companieshouse/docker-chs-development/pull/1825

## Checklist

- [x] Adhered to the [coding style guidelines](https://companieshouse.atlassian.net/wiki/spaces/DEV/pages/4290084946/Coding+Standards+and+Styleguides).
- [ ] Added/updated logging appropriately.
- [ ] Written tests.
- [x] Tested the new code in my local environment.
- [x] Updated Docker/ECS configs.
- [x] Added all new properties to chs-configs.
- [ ] Updated release notes.

Strikethrough (`~~like this~~`) anything not applicable to your changes.
