### PR TITLE
Add a space at end of word, which matches the english value

### DIFF
--- a/locales/cy/personal-code.json
+++ b/locales/cy/personal-code.json
@@ -2,7 +2,7 @@
   "personal_code_title": "Beth yw eu cod personol T\u0177 Cwmn\u00efau?",
   "personal_code_details_summaryText": "Ble i ddod o hyd i god personol T\u0177\u0027r Cwmn\u00efau",
   "personal_code_details_text": "Mae hwn yn god 11 nod sy\u0027n cael ei roi i berson ar \u00f4l iddynt gwblhau gwiriad hunaniaeth gyda Th\u0177\u0027r Cwmn\u00efau.",
-  "personal_code_born": "Ganwyd",
+  "personal_code_born": "Ganwyd ",
   "personal_code_button": "Cadw a pharhau",
   "personal_code_error_summary": "Cofnodwch god personol T\u0177\u0027r Cwmn\u00efau",
   "personal_code_error_inline": "Cofnodwch god personol T\u0177\u0027r Cwmn\u00efau"


### PR DESCRIPTION
**Jira ticket**: part of IDVA3-1108

## Add a space at end of word, which matches the english value

## Fix for this:
![Screenshot 2025-07-02 at 11 23 31 am](https://github.com/user-attachments/assets/adb05fab-55c9-40f6-8e5c-d2671b90b5ff)

## Test notes
>
> Add test notes only if they're **not** already included in the Jira ticket.

## Checklist

- [x] Adhered to the [coding style guidelines](https://companieshouse.atlassian.net/wiki/spaces/DEV/pages/4290084946/Coding+Standards+and+Styleguides).
- [ ] Added/updated logging appropriately.
- [ ] Written tests.
- [ ] Tested the new code in my local environment.
- [ ] Updated Docker/ECS configs.
- [ ] Added all new properties to chs-configs.
- [ ] Updated release notes.

Strikethrough (`~~like this~~`) anything not applicable to your changes.
