### PR TITLE
Add welsh language values for statement screen

### DIFF
--- a/locales/cy/individual-statement.json
+++ b/locales/cy/individual-statement.json
@@ -1,10 +1,10 @@
 {
-    "individual_statement_title": "To be translated: individual_statement_title",
-    "individual_statement_value": "To be translated: individual_statement_value",
-    "individual_statement_part1": "To be translated: individual_statement_part1",
-    "individual_statement_part2": "To be translated: individual_statement_part2",
-    "individual_statement_born": "To be translated: individual_statement_born",
-    "individual_statement_button": "To be translated: individual_statement_button",
-    "individual_statement_error_summary": "To be translated: individual_statement_error_summary",
-    "individual_statement_error_inline": "To be translated: individual_statement_error_inline"
+    "individual_statement_value": "Cadarnhewch y datganiad gwiriad hunaniaeth",
+    "individual_statement_part1": "datganiad unigol",
+    "individual_statement_title": "Rwy\u0027n cadarnhau bod ",
+    "individual_statement_part2": "wedi cwblhau gwiriad hunaniaeth yn unol \u00e2 Deddf Cwmn\u00efau 2006.",
+    "individual_statement_born": "Ganwyd ",
+    "individual_statement_button": "Cadarnhau a chyflwyno",
+    "individual_statement_error_summary": "Dewiswch y datganiad gwiriad hunaniaeth",
+    "individual_statement_error_inline": "Dewiswch y datganiad gwiriad hunaniaeth"
 }

--- a/locales/cy/start.json
+++ b/locales/cy/start.json
@@ -1,5 +1,5 @@
 {
-    "start_main_title": "Darparwch fanylion gwiriad hunaniaeth ar gyfer person \u2038 rheolaeth arwyddocaol (PRhA)",
+    "start_main_title": "Darparwch fanylion gwiriad hunaniaeth ar gyfer person \u00e2 rheolaeth arwyddocaol (PRhA)",
     "start_service_description_1": "To be translated: start_service_description_1",
     "start_service_description_2": "To be translated: start_service_description_2",
     "start_personal_code_details_main_link": "To be translated: start_personal_code_details_main_link",


### PR DESCRIPTION
**Jira ticket**: IDVA3-1109 & IDVA3-3292

## Brief description of the change(s):
- add welsh language values for statement screen
- also fixed the 'a caret' letter in the top banner


## Working example
<img width="1018" alt="Screenshot 2025-07-02 at 12 11 54 pm" src="https://github.com/user-attachments/assets/d741eee4-58e2-4599-8795-d5baa3e1e8fa" />

## Checklist

- [x] Adhered to the [coding style guidelines](https://companieshouse.atlassian.net/wiki/spaces/DEV/pages/4290084946/Coding+Standards+and+Styleguides).
- [ ] Added/updated logging appropriately.
- [ ] Written tests.
- [x] Tested the new code in my local environment.
- [ ] Updated Docker/ECS configs.
- [ ] Added all new properties to chs-configs.
- [ ] Updated release notes.

Strikethrough (`~~like this~~`) anything not applicable to your changes.
