### PR TITLE
Fix DataIntegrityError missing context

### DIFF
--- a/src/middleware/error-interceptors/dataIntegrityErrorInterceptor.ts
+++ b/src/middleware/error-interceptors/dataIntegrityErrorInterceptor.ts
@@ -4,8 +4,9 @@ import { HttpStatusCode } from "axios";
 import { PrefixedUrls, STOP_TYPE } from "../../constants";
 import { getUrlWithStopType } from "../../utils/url";
 import { logger } from "../../lib/logger";
+import { addSearchParams } from "../../utils/queryParams";
 
-export function dataIntegrityErrorInterceptor (err: Error | DataIntegrityError, _: Request, res: Response, next: NextFunction): void {
+export function dataIntegrityErrorInterceptor (err: Error | DataIntegrityError, req: Request, res: Response, next: NextFunction): void {
     if (!(err instanceof DataIntegrityError)) {
         return next(err);
     }
@@ -13,7 +14,13 @@ export function dataIntegrityErrorInterceptor (err: Error | DataIntegrityError, 
 
     if (err.type === DataIntegrityErrorType.PSC_DATA) {
         res.status(HttpStatusCode.InternalServerError);
-        res.redirect(getUrlWithStopType(PrefixedUrls.STOP_SCREEN, STOP_TYPE.PROBLEM_WITH_PSC_DATA));
+        const query = req.query || {};
+        const companyNumber = typeof query.companyNumber === "string" ? query.companyNumber : "";
+        const lang = typeof query.lang === "string" ? query.lang : "";
+        res.redirect(addSearchParams(
+            getUrlWithStopType(PrefixedUrls.STOP_SCREEN, STOP_TYPE.PROBLEM_WITH_PSC_DATA),
+            { companyNumber, lang }
+        ));
     } else {
         return next(new Error(`Unhandled DataIntegrityError type: ${err.type}`));
     }

--- a/test/middleware/error-interceptors/dataIntegrityErrorInterceptor.unit.ts
+++ b/test/middleware/error-interceptors/dataIntegrityErrorInterceptor.unit.ts
@@ -31,12 +31,39 @@ describe("dataIntegrityErrorInterceptor", () => {
 
     it("should log the error and redirect for PSC_DATA type", () => {
         const error = new DataIntegrityError("PSC data issue", DataIntegrityErrorType.PSC_DATA);
-
+        req.query = { companyNumber: "12345678", lang: "en" };
         dataIntegrityErrorInterceptor(error, req as Request, res as Response, next);
-
         expect(logger.error).toHaveBeenCalledWith(`${error.stack}`);
         expect(res.status).toHaveBeenCalledWith(HttpStatusCode.InternalServerError);
-        expect(res.redirect).toHaveBeenCalledWith("/persons-with-significant-control-verification/stop/problem-with-psc-data");
+        expect(res.redirect).toHaveBeenCalledWith("/persons-with-significant-control-verification/stop/problem-with-psc-data?companyNumber=12345678&lang=en");
+    });
+
+    it("should handle PSC_DATA type with undefined req.query", () => {
+        const error = new DataIntegrityError("PSC data issue", DataIntegrityErrorType.PSC_DATA);
+        req.query = undefined;
+        dataIntegrityErrorInterceptor(error, req as Request, res as Response, next);
+        expect(logger.error).toHaveBeenCalledWith(`${error.stack}`);
+        expect(res.status).toHaveBeenCalledWith(HttpStatusCode.InternalServerError);
+        expect(res.redirect).toHaveBeenCalledWith("/persons-with-significant-control-verification/stop/problem-with-psc-data?companyNumber=&lang=");
+    });
+
+    it("should handle PSC_DATA type with null req.query (simulated as undefined)", () => {
+        const error = new DataIntegrityError("PSC data issue", DataIntegrityErrorType.PSC_DATA);
+        // TypeScript does not allow null, so simulate with undefined
+        req.query = undefined;
+        dataIntegrityErrorInterceptor(error, req as Request, res as Response, next);
+        expect(logger.error).toHaveBeenCalledWith(`${error.stack}`);
+        expect(res.status).toHaveBeenCalledWith(HttpStatusCode.InternalServerError);
+        expect(res.redirect).toHaveBeenCalledWith("/persons-with-significant-control-verification/stop/problem-with-psc-data?companyNumber=&lang=");
+    });
+
+    it("should handle PSC_DATA type with missing companyNumber and lang", () => {
+        const error = new DataIntegrityError("PSC data issue", DataIntegrityErrorType.PSC_DATA);
+        req.query = {};
+        dataIntegrityErrorInterceptor(error, req as Request, res as Response, next);
+        expect(logger.error).toHaveBeenCalledWith(`${error.stack}`);
+        expect(res.status).toHaveBeenCalledWith(HttpStatusCode.InternalServerError);
+        expect(res.redirect).toHaveBeenCalledWith("/persons-with-significant-control-verification/stop/problem-with-psc-data?companyNumber=&lang=");
     });
 
     it("should pass unhandled DataIntegrityError types to the next middleware as a generic error", () => {

--- a/test/routers/handlers/stop-screen/stopScreen.int.ts
+++ b/test/routers/handlers/stop-screen/stopScreen.int.ts
@@ -93,7 +93,7 @@ describe("stop screen view tests", () => {
                 expect($("a#mail-to-dsr").attr("href")).toBe(`mailto:${env.DSR_EMAIL_ADDRESS}`);
                 break;
             case STOP_TYPE.PROBLEM_WITH_PSC_DATA:
-                expect($("p.govuk-body").text()).toContain("You'll need to call or email Companies House to resolve it before you can provide verification details. You'll be asked to provide the company number.");
+                expect($("p.govuk-body").text()).toContain("call or email Companies House");
                 break;
             default:
                 throw new Error(`Untested STOP_TYPE value: ${stopType}`);


### PR DESCRIPTION
- fix thrown DataIntegrityError not propagating request context (companyNumber, lang) needed for link URLs
- add test coverage
- fix failing stop screen test after text changes. Make test less brittle.

**Jira ticket**: 
IDVA3-3321

## Brief description of the change(s)
Fix problem-with-psc-data stop screen has incorrect link URL for 'Cymraeg' link

## Test notes
>
> Add test notes only if they're **not** already included in the Jira ticket.

## Checklist

- [x] Adhered to the [coding style guidelines](https://companieshouse.atlassian.net/wiki/spaces/DEV/pages/4290084946/Coding+Standards+and+Styleguides).
- ~~[ ] Added/updated logging appropriately.~~
- [x] Written tests.
- [x] Tested the new code in my local environment.
- ~~[ ] Updated Docker/ECS configs.~~
- ~~[ ] Added all new properties to chs-configs.~~
- [ ] Updated release notes.

Strikethrough (`~~like this~~`) anything not applicable to your changes.
