### PR TITLE
Correct the key/values for welsh that had been mixed up

### DIFF
--- a/locales/cy/individual-statement.json
+++ b/locales/cy/individual-statement.json
@@ -1,8 +1,7 @@
 {
-    "individual_statement_value": "Cadarnhewch y datganiad gwiriad hunaniaeth",
-    "individual_statement_part1": "datganiad unigol",
-    "individual_statement_title": "Rwy\u0027n cadarnhau bod ",
-    "individual_statement_part2": "wedi cwblhau gwiriad hunaniaeth yn unol \u00e2 Deddf Cwmn\u00efau 2006.",
+    "individual_statement_title": "Cadarnhewch y datganiad gwiriad hunaniaeth",
+    "individual_statement_part1": "Rwy’n cadarnhau bod ",
+    "individual_statement_part2": "wedi cwblhau gwiriad hunaniaeth yn unol â Deddf Cwmnïau 2006.",
     "individual_statement_born": "Ganwyd ",
     "individual_statement_button": "Cadarnhau a chyflwyno",
     "individual_statement_error_summary": "Dewiswch y datganiad gwiriad hunaniaeth",

--- a/locales/en/individual-statement.json
+++ b/locales/en/individual-statement.json
@@ -1,8 +1,7 @@
 {
     "individual_statement_title": "Confirm the identity verification statement",
-    "individual_statement_value": "individual_statement",
     "individual_statement_part1": "I confirm that ",
-    "individual_statement_part2": " has verified their identity in accordance with the Companies Act 2006.",
+    "individual_statement_part2": "has verified their identity in accordance with the Companies Act 2006.",
     "individual_statement_born": "Born ",
     "individual_statement_button": "Confirm and submit",
     "individual_statement_error_summary": "Select the identity verification statement",


### PR DESCRIPTION
**Jira ticket**: IDVA3-3320

## Correct the key/values for welsh that had been mixed up in IDVA3-1109
- replace unicode values
- remove unused key

## Working example
<img width="970" alt="Screenshot 2025-07-04 at 11 59 14 am" src="https://github.com/user-attachments/assets/0822a43f-e63d-4a6a-b2dd-382d41c54dec" />
<img width="1074" alt="Screenshot 2025-07-04 at 11 59 31 am" src="https://github.com/user-attachments/assets/3f38b324-3f50-4b0a-8e74-c9a4ce0c4001" />

## Checklist

- [x] Adhered to the [coding style guidelines](https://companieshouse.atlassian.net/wiki/spaces/DEV/pages/4290084946/Coding+Standards+and+Styleguides).
- [ ] Added/updated logging appropriately.
- [ ] Written tests.
- [ ] Tested the new code in my local environment.
- [ ] Updated Docker/ECS configs.
- [ ] Added all new properties to chs-configs.
- [ ] Updated release notes.

Strikethrough (`~~like this~~`) anything not applicable to your changes.
