### PR TITLE
IDVA3-3322 Fix cross-session email data leak

### DIFF
--- a/src/middleware/error-interceptors/httpErrorInterceptor.ts
+++ b/src/middleware/error-interceptors/httpErrorInterceptor.ts
@@ -1,7 +1,7 @@
 import { NextFunction, Request, Response } from "express";
 import { logger } from "../../lib/logger";
 import { HttpError } from "../../lib/errors/httpError";
-import { defaultBaseViewData } from "../../routers/handlers/generic";
+import { getViewData } from "../../routers/handlers/generic";
 import { getLocaleInfo, getLocalesService, selectLang } from "../../utils/localise";
 import { njk } from "../../app";
 import { HttpStatusCode } from "axios";
@@ -50,11 +50,13 @@ export const httpErrorInterceptor = (error: HttpError | Error, req: Request, res
     const lang = selectLang(req.query.lang);
     const locales = getLocalesService();
 
-    res.render(templatePath, {
-        ...defaultBaseViewData,
-        ...getLocaleInfo(locales, lang),
-        currentUrl: req.originalUrl,
-        extraData: [env.CONTACT_US_LINK]
+    getViewData(req, res, lang).then((baseViewData) => {
+        res.render(templatePath, {
+            ...baseViewData,
+            ...getLocaleInfo(locales, lang),
+            currentUrl: req.originalUrl,
+            extraData: [env.CONTACT_US_LINK]
+        });
     });
 };
 

--- a/src/routers/handlers/generic.ts
+++ b/src/routers/handlers/generic.ts
@@ -59,7 +59,7 @@ export abstract class GenericHandler<T extends BaseViewData> {
     private viewData!: T;
 
     async getViewData (req: Request, res: Response, lang: string = "en"): Promise<T> {
-        this.errorManifest = errorManifest();
+        this.errorManifest = errorManifest(lang);
         this.viewData = await getViewData<T>(req, res, lang);
         return this.viewData;
     }

--- a/src/routers/handlers/generic.ts
+++ b/src/routers/handlers/generic.ts
@@ -44,6 +44,7 @@ export function populateViewData<T extends BaseViewData> (viewData: T, req: Requ
         viewData.userEmail = userEmail;
     } else {
         logger.error("GenericHandler unable to get email. Email is undefined.");
+        viewData.userEmail = ""; // Blank email to avoid a scenario where the email is undefined
     }
 }
 

--- a/src/routers/handlers/generic.ts
+++ b/src/routers/handlers/generic.ts
@@ -4,6 +4,7 @@
 import { Request, Response } from "express";
 import { ExternalUrls, PrefixedUrls, servicePathPrefix } from "../../constants";
 import errorManifest from "../../lib/utils/error-manifests/errorManifest";
+import { logger } from "../../lib/logger";
 
 export interface BaseViewData {
     errors: any
@@ -31,42 +32,42 @@ export const defaultBaseViewData: Partial<BaseViewData> = {
     templateName: null
 } as const;
 
-export interface Redirect {
-    redirect: string
+export function populateViewData<T extends BaseViewData> (viewData: T, req: Request, res: Response): void {
+    const { signin_info: signInInfo } = req.session?.data ?? {};
+    const isSignedIn = signInInfo?.signed_in !== undefined;
+    viewData.isSignedIn = isSignedIn;
+
+    if (!isSignedIn) { return; }
+
+    const userEmail = signInInfo?.user_profile?.email;
+    if (userEmail) {
+        viewData.userEmail = userEmail;
+    } else {
+        logger.error("GenericHandler unable to get email. Email is undefined.");
+    }
+}
+
+export async function getViewData<T extends BaseViewData> (req: Request, res: Response, lang: string = "en"): Promise<T> {
+    const viewData = defaultBaseViewData as T;
+    populateViewData(viewData, req, res);
+    return viewData;
 }
 
 export abstract class GenericHandler<T extends BaseViewData> {
     protected errorManifest!: ReturnType<typeof errorManifest>;
     private viewData!: T;
 
+    async getViewData (req: Request, res: Response, lang: string = "en"): Promise<T> {
+        this.errorManifest = errorManifest();
+        this.viewData = await getViewData<T>(req, res, lang);
+        return this.viewData;
+    }
+
     processHandlerException (err: any): Object {
         if (err.name === "VALIDATION_ERRORS") {
             return err.stack;
         }
-
         throw err;
-    }
-
-    populateViewData (req: Request, res: Response) {
-        const { signin_info: signInInfo } = req.session?.data ?? {};
-        const isSignedIn = signInInfo?.signed_in !== undefined;
-        this.viewData.isSignedIn = isSignedIn;
-
-        if (!isSignedIn) { return; }
-
-        const userEmail = signInInfo?.user_profile?.email;
-        if (!userEmail) {
-            throw new Error("GenericHandler unable to get email. Email is undefined.");
-        }
-
-        this.viewData.userEmail = userEmail;
-    }
-
-    async getViewData (req: Request, res: Response, lang: string = "en"): Promise<T> {
-        this.errorManifest = errorManifest(lang);
-        this.viewData = defaultBaseViewData as T;
-        this.populateViewData(req, res);
-        return this.viewData;
     }
 }
 

--- a/test/routers/handlers/generic.unit.ts
+++ b/test/routers/handlers/generic.unit.ts
@@ -1,0 +1,92 @@
+import { Request, Response } from "express";
+import * as generic from "../../../src/routers/handlers/generic";
+
+jest.mock("../../../src/lib/logger", () => ({
+    logger: { error: jest.fn() }
+}));
+
+jest.mock("../../../src/lib/utils/error-manifests/errorManifest", () => jest.fn(() => "mockedErrorManifest"));
+
+describe("populateViewData", () => {
+    let req: any;
+    let res: Partial<Response>;
+    let viewData: any;
+
+    beforeEach(() => {
+        req = { session: { data: {} } };
+        res = {};
+        viewData = {};
+        jest.clearAllMocks();
+    });
+
+    it("sets isSignedIn to false if not signed in", () => {
+        req.session = { data: {} };
+        generic.populateViewData(viewData, req as Request, res as Response);
+        expect(viewData.isSignedIn).toBe(false);
+    });
+
+    it("sets isSignedIn to true and userEmail if signed in and email present", () => {
+        req.session = { data: { signin_info: { signed_in: 1, user_profile: { email: "test@example.com" } } } };
+        generic.populateViewData(viewData, req as Request, res as Response);
+        expect(viewData.isSignedIn).toBe(true);
+        expect(viewData.userEmail).toBe("test@example.com");
+    });
+
+    it("sets userEmail to blank and logs error if signed in but email missing", () => {
+        req.session = { data: { signin_info: { signed_in: 1, user_profile: {} } } };
+        generic.populateViewData(viewData, req as Request, res as Response);
+        expect(viewData.isSignedIn).toBe(true);
+        expect(viewData.userEmail).toBe("");
+        const { logger } = require("../../../src/lib/logger");
+        expect(logger.error).toHaveBeenCalledWith(
+            "GenericHandler unable to get email. Email is undefined."
+        );
+    });
+});
+
+describe("getViewData", () => {
+    it("returns defaultBaseViewData with isSignedIn false if not signed in", async () => {
+        const req: any = { session: { data: {} } };
+        const res = {} as Partial<Response>;
+        const data = await generic.getViewData(req as Request, res as Response);
+        expect(data.isSignedIn).toBe(false);
+        expect(data.title).toBe("Apply to file with Companies House using software");
+    });
+
+    it("returns viewData with isSignedIn true and userEmail if signed in", async () => {
+        const req: any = { session: { data: { signin_info: { signed_in: 1, user_profile: { email: "foo@bar.com" } } } } };
+        const res = {} as Partial<Response>;
+        const data = await generic.getViewData(req as Request, res as Response);
+        expect(data.isSignedIn).toBe(true);
+        expect(data.userEmail).toBe("foo@bar.com");
+    });
+});
+
+describe("GenericHandler", () => {
+    class TestHandler extends generic.GenericHandler<any> {
+        public getErrorManifest () {
+            return this.errorManifest;
+        }
+    }
+
+    it("getViewData sets errorManifest and viewData", async () => {
+        const handler = new TestHandler();
+        const req: any = { session: { data: {} } };
+        const res = {} as Partial<Response>;
+        const data = await handler.getViewData(req as Request, res as Response);
+        expect(handler.getErrorManifest()).toBe("mockedErrorManifest");
+        expect(data).toBeDefined();
+    });
+
+    it("processHandlerException returns stack for VALIDATION_ERRORS", () => {
+        const handler = new TestHandler();
+        const err = { name: "VALIDATION_ERRORS", stack: "stacktrace" };
+        expect(handler.processHandlerException(err)).toBe("stacktrace");
+    });
+
+    it("processHandlerException throws for other errors", () => {
+        const handler = new TestHandler();
+        const err = new Error("Some error");
+        expect(() => handler.processHandlerException(err)).toThrow(err);
+    });
+});


### PR DESCRIPTION
**Jira ticket**: https://companieshouse.atlassian.net/browse/IDVA3-3322

## Brief description of the change(s)

The bug seems to be caused by a view being displayed without setting the bits of viewData that routers & handlers add by default (specifically userEmail). Without this, Nunjucks seems to fall through to whatever email was rendered last, which is a serious flaw. This PR fixes the issue, but we ought to investigate further into how Nunjucks caches information like this.

The key change is that the viewData populating functionality was extracted out of GenericHandler so it can also be used by error interceptors and non router/handler constructs like middleware.

## Working example
>
> Use screenshots or logs to show what your changes do.

<img width="2551" alt="image" src="https://github.com/user-attachments/assets/086b753f-0280-4e59-a152-823859744b63" />

The screenshot above shows two browsers, one in private mode. The one on the left is `demo@ch.gov.uk` whereas the one on the right is `demo2@ch.gov.uk`. After refreshing `demo2` and then `demo`, this is still the case.

## Test notes
>
> Add test notes only if they're **not** already included in the Jira ticket.

The section above alludes to how to test. Set up the browsers as explained, navigate both to psc-list, reword the url to something like `psc-listx` for `demo` to trigger a 404. Once it's loaded, refresh `demo2`'s screen, wait for it to load fully, and then refresh `demo`'s screen. Before the fix, the browser on the left would show `demo2@ch.gov.uk`, after the fix it correctly displays `demo@ch.gov.uk`

## Checklist

- [x] Adhered to the [coding style guidelines](https://companieshouse.atlassian.net/wiki/spaces/DEV/pages/4290084946/Coding+Standards+and+Styleguides).
- [x] Added/updated logging appropriately.
- [x] Written tests.
- [x] Tested the new code in my local environment.
- [ ] Updated Docker/ECS configs.
- [ ] Added all new properties to chs-configs.
- [ ] Updated release notes.

Strikethrough (`~~like this~~`) anything not applicable to your changes.
