### PR TITLE
Fix footer accessibility link to incorrect lang

### DIFF
--- a/locales/cy/global.json
+++ b/locales/cy/global.json
@@ -12,6 +12,7 @@
     "global_footer_policies": "Polisïau",
     "global_footer_cookies": "Cwcis",
     "global_footer_contact_us": "Cysylltwch â ni",
+    "global_footer_accessibility_url": "/persons-with-significant-control-verification/accessibility-statement?lang=cy",
     "global_footer_ogl_v3": "Drwydded Llywodraeth Agored v3.0",
     "global_footer_ogl_v3_url": "https://www.nationalarchives.gov.uk/doc/open-government-licence-cymraeg/version/3/",
     "global_footer_licence_p1": "Mae'r holl gynnwys ar gael o dan y ",

--- a/locales/en/global.json
+++ b/locales/en/global.json
@@ -12,6 +12,7 @@
     "global_footer_policies": "Policies",
     "global_footer_cookies": "Cookies",
     "global_footer_contact_us": "Contact us",
+    "global_footer_accessibility_url": "/persons-with-significant-control-verification/accessibility-statement",
     "global_footer_ogl_v3": "Open Government Licence v3.0",
     "global_footer_ogl_v3_url": "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
     "global_footer_licence_p1": "All content is available under the ",

--- a/src/views/partials/__footer.njk
+++ b/src/views/partials/__footer.njk
@@ -27,7 +27,7 @@
         attributes: { "data-event-id": "contact-footer-link" }
       },
             {
-        href: accessibilityStatementLink,
+        href: i18n.global_footer_accessibility_url,
         text: i18n.global_footer_accessibility_statement,
         attributes: { "data-event-id": "accessibility-footer-link" }
       }

--- a/test/routers/start.int.ts
+++ b/test/routers/start.int.ts
@@ -142,6 +142,27 @@ describe("Start router/handler integration tests", () => {
 
         });
 
+        it("should render the footer with the expected links in Welsh when user has selected 'Cymraeg' link", async () => {
+            const resp = await request(app).get(`${servicePathPrefix}?lang=cy`);
+            expect(resp.status).toBe(HttpStatusCode.Ok);
+            const $ = cheerio.load(resp.text);
+
+            const expectedLinks = [
+                { href: "https://resources.companieshouse.gov.uk/serviceInformation.shtml", text: "Polisïau" },
+                { href: "/help/cookies", text: "Cwcis" },
+                { href: "https://www.gov.uk/government/organisations/companies-house#org-contacts", text: "Cysylltwch â ni" },
+                { href: "/persons-with-significant-control-verification/accessibility-statement?lang=cy", text: "Hygyrchedd" }
+            ];
+
+            const footerLinks = $(".govuk-footer__inline-list-item a");
+            expect(footerLinks.length).toBe(expectedLinks.length);
+
+            expectedLinks.forEach((link, i) => {
+                expect(footerLinks.eq(i).attr("href")).toBe(link.href);
+                expect(footerLinks.eq(i).text().trim()).toBe(link.text);
+            });
+        });
+
         it("should render the Open Government Licence link correctly", async () => {
 
             const resp = await request(app).get(servicePathPrefix);


### PR DESCRIPTION
- move accessibility links to i18n global.json (en/cy)
- use i18n url as link target in footer
- add integration tests for Welsh footer text and links

**Jira ticket**: 
IDVA3-3340

## Checklist

- [x] Adhered to the [coding style guidelines](https://companieshouse.atlassian.net/wiki/spaces/DEV/pages/4290084946/Coding+Standards+and+Styleguides).
- ~~[ ] Added/updated logging appropriately.~~
- [x] Written tests.
- [x] Tested the new code in my local environment.
- ~~[ ] Updated Docker/ECS configs.~~
- ~~[ ] Added all new properties to chs-configs.~~
- ~~[ ] Updated release notes.~~

Strikethrough (`~~like this~~`) anything not applicable to your changes.
