### PR TITLE
Quick fix: hardcode govuk-frontend version

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -16,7 +16,6 @@ import { HttpStatusCode } from "axios";
 import { dataIntegrityErrorInterceptor } from "./middleware/error-interceptors/dataIntegrityErrorInterceptor";
 import { requestLogger } from "./middleware/requestLogger";
 import { requestIdGenerator } from "./middleware/requestIdGenerator";
-import { getGOVUKFrontendVersion } from "@companieshouse/ch-node-utils";
 
 const app = express();
 
@@ -83,7 +82,7 @@ njk.addGlobal("PIWIK_SITE_ID", process.env.PIWIK_SITE_ID);
 njk.addGlobal("PIWIK_URL", process.env.PIWIK_URL);
 njk.addGlobal("verifyIdentityLink", process.env.VERIFY_IDENTITY_LINK);
 njk.addGlobal("accessibilityStatementLink", PrefixedUrls.ACCESSIBILITY_STATEMENT);
-njk.addGlobal("govukFrontendVersion", getGOVUKFrontendVersion());
+njk.addGlobal("govukFrontendVersion", "5.11.0");
 njk.addGlobal("govukRebrand", true);
 
 // if app is behind a front-facing proxy, and to use the X-Forwarded-* headers to determine the connection and the IP address of the client


### PR DESCRIPTION
**Jira ticket**: None

## Brief description of the change(s)

Hardcodes the govuk frontend version due to an issue where `getGOVUKFrontendVersion` expects `package.json` to be present in ECS (which isn't the case for psc-verification-web). Should unblock `cidev-apply`.
