### PR TITLE
Removing unnecessary content from local Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,7 @@
-FROM node:22
+ARG IMAGE_VERSION="latest"
+FROM 416670754337.dkr.ecr.eu-west-2.amazonaws.com/ci-node-runtime-22:${IMAGE_VERSION}
 
-ARG SSH_KEY
-ENV SSH_KEY=$SSH_KEY
-# Make ssh dir
-RUN mkdir /root/.ssh/
-# Create id_rsa from string arg, and set permissions
-RUN echo "$SSH_KEY" >/root/.ssh/id_rsa
-RUN chmod 600 /root/.ssh/id_rsa
-# Create known_hosts
-RUN touch /root/.ssh/known_hosts
-# Add git providers to known_hosts
-RUN ssh-keyscan bitbucket.org >>/root/.ssh/known_hosts
-RUN ssh-keyscan github.com >>/root/.ssh/known_hosts
-RUN ssh-keyscan gitlab.com >>/root/.ssh/known_hosts
 WORKDIR /app
 COPY package*.json ./
 RUN npm install
 COPY . .
-CMD [ "npm", "run", "start:watch" ]
-# ENTRYPOINT [ "bash" ]

--- a/docker_start.sh
+++ b/docker_start.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-# Start script for psc-verification-web
-
-exec npm run start:watch


### PR DESCRIPTION
**Jira ticket**: IDVA3-1083

## Brief description of the change(s)
- I think actually we need to maintain the Dockerfile in `/ecs-image-build` and at the root.  I see this pattern in other projects.
- I don't see the `/docker_start.sh` being used at all
- have copied the FROM line from the  `/ecs-image-build/Dockerfile` for consistency
- `start:watch` isn't in our package scripts, so removing from Dockerfile

## Test notes
This is what I checked for:
- service starts in dev mode and non-dev mode
- can still attach debugger when in dev mode
- can still make update to a template when in dev mode

## Checklist

- [x] Adhered to the [coding style guidelines](https://companieshouse.atlassian.net/wiki/spaces/DEV/pages/4290084946/Coding+Standards+and+Styleguides).
- [ ] Added/updated logging appropriately.
- [ ] Written tests.
- [ ] Tested the new code in my local environment.
- [ ] Updated Docker/ECS configs.
- [ ] Added all new properties to chs-configs.
- [ ] Updated release notes.

Strikethrough (`~~like this~~`) anything not applicable to your changes.
