### PR TITLE
Revert hardcoded govuk frontend version & attempt fix via Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ endif
 	cp -r ./api-enumerations/*.yml $(tmpdir)/api-enumerations
 	cp ./routes.yaml $(tmpdir)
 	cd $(tmpdir) && export GIT_SSH_COMMAND="ssh" && npm ci --production
-	rm $(tmpdir)/package.json $(tmpdir)/package-lock.json
+	rm $(tmpdir)/package-lock.json
 	cd $(tmpdir) && zip -r ../$(artifact_name)-$(version).zip .
 	rm -rf $(tmpdir)
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -16,6 +16,7 @@ import { HttpStatusCode } from "axios";
 import { dataIntegrityErrorInterceptor } from "./middleware/error-interceptors/dataIntegrityErrorInterceptor";
 import { requestLogger } from "./middleware/requestLogger";
 import { requestIdGenerator } from "./middleware/requestIdGenerator";
+import { getGOVUKFrontendVersion } from "@companieshouse/ch-node-utils";
 
 const app = express();
 
@@ -82,7 +83,7 @@ njk.addGlobal("PIWIK_SITE_ID", process.env.PIWIK_SITE_ID);
 njk.addGlobal("PIWIK_URL", process.env.PIWIK_URL);
 njk.addGlobal("verifyIdentityLink", process.env.VERIFY_IDENTITY_LINK);
 njk.addGlobal("accessibilityStatementLink", PrefixedUrls.ACCESSIBILITY_STATEMENT);
-njk.addGlobal("govukFrontendVersion", "5.11.0");
+njk.addGlobal("govukFrontendVersion", getGOVUKFrontendVersion());
 njk.addGlobal("govukRebrand", true);
 
 // if app is behind a front-facing proxy, and to use the X-Forwarded-* headers to determine the connection and the IP address of the client


### PR DESCRIPTION
**Jira ticket**: N/a

## Brief description of the change(s)

Prevents our Makefile build step from removing `package.json` to hopefully fix ECS falling over due to `getGOVUKFrontendVersion()` expecting `package.json` to be present.

## Working example
>
> Use screenshots or logs to show what your changes do.

Results will be whether the cidev-apply task finishes successfully.

## Test notes
>
> Add test notes only if they're **not** already included in the Jira ticket.

N/a

## Checklist

- [x] Adhered to the [coding style guidelines](https://companieshouse.atlassian.net/wiki/spaces/DEV/pages/4290084946/Coding+Standards+and+Styleguides).
- [ ] ~~Added/updated logging appropriately.~~
- [ ] ~~Written tests.~~
- [ ] ~~Tested the new code in my local environment.~~
- [ ] ~~Updated Docker/ECS configs.~~
- [ ] ~~Added all new properties to chs-configs.~~
- [ ] ~~Updated release notes.~~

Strikethrough (`~~like this~~`) anything not applicable to your changes.
