### PR TITLE
IDVA3-3396 Fix broken error-summary layout

### DIFF
--- a/src/views/partials/error-summary.njk
+++ b/src/views/partials/error-summary.njk
@@ -1,7 +1,5 @@
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
-<div class="govuk-grid-column-{{ gridColumnClass | default('two-thirds') }}">
-
 {% if errors is not undefined and errors is not null and errors | length %}
 <div class="govuk-error-summary" data-module="govuk-error-summary">
   <div role="alert">
@@ -26,5 +24,3 @@
   </div>
 </div>
 {% endif %}
-
-</div>

--- a/src/views/router_views/personalCode/personal-code.njk
+++ b/src/views/router_views/personalCode/personal-code.njk
@@ -15,14 +15,14 @@
 ] | join %}
 
 {% block main_content %}
+    <span class="govuk-caption-xl">
+        {{ nameAndDateBirthText }}
+    </span>
+    <h1 class="govuk-heading-l" id="personal-code--title">
+        {{ title }}
+    </h1>
     <form action="" method="post">
         {% include "includes/csrf-token.njk" %}
-        <span class="govuk-caption-xl">
-            {{ nameAndDateBirthText }}
-        </span>
-        <h1 class="govuk-heading-l" id="personal-code--title">
-            {{ title }}
-        </h1>
         
         <div class="govuk-form-group">
             {% set inputOptions = {


### PR DESCRIPTION
**Jira ticket**: https://companieshouse.atlassian.net/browse/IDVA3-3396

## Brief description of the change(s)

Fixes a regression due to the rebrand where the error-summary.njk template had an additional layout div.

## Working example
>
> Use screenshots or logs to show what your changes do.

<img width="1219" height="1279" alt="image" src="https://github.com/user-attachments/assets/2ff57484-0af1-4114-bf32-ba901fcc50d0" />

## Test notes
>
> Add test notes only if they're **not** already included in the Jira ticket.

Included in Jira.

## Checklist

- [x] Adhered to the [coding style guidelines](https://companieshouse.atlassian.net/wiki/spaces/DEV/pages/4290084946/Coding+Standards+and+Styleguides).
- [ ] Added/updated logging appropriately.
- [ ] Written tests.
- [x] Tested the new code in my local environment.
- [ ] Updated Docker/ECS configs.
- [ ] Added all new properties to chs-configs.
- [ ] Updated release notes.

Strikethrough (`~~like this~~`) anything not applicable to your changes.
