### PR TITLE
IDVA3-3385 Update web to use data retrieved from public endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "license": "MIT",
             "dependencies": {
-                "@companieshouse/api-sdk-node": "^2.0.280",
+                "@companieshouse/api-sdk-node": "^2.0.290",
                 "@companieshouse/ch-node-utils": "^2.1.8",
                 "@companieshouse/node-session-handler": "^5.2.4",
                 "@companieshouse/structured-logging-node": "^2.0.2",
@@ -625,9 +625,9 @@
             }
         },
         "node_modules/@companieshouse/api-sdk-node": {
-            "version": "2.0.280",
-            "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.280.tgz",
-            "integrity": "sha512-tZytEagK0Q9jZEOGBdH6xMR/HWCqjvY7Qtz286I3FB14HBZNbzhAFcipp2f/vJlQCtQkhecUedVqTPKgLF7g5g==",
+            "version": "2.0.290",
+            "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.290.tgz",
+            "integrity": "sha512-yP6+fws3n4bdS3vzAn0bY0SglQfq9AiiGB05ikR89HfBQTpPmY7MLUarFXTTw1Tb4ESP64/eG3g99T53AA0AcA==",
             "license": "MIT",
             "dependencies": {
                 "axios": "^1.8.2",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "author": "Moses Wejuli <mwejuli@companieshouse.gov.uk>",
     "license": "MIT",
     "dependencies": {
-        "@companieshouse/api-sdk-node": "^2.0.280",
+        "@companieshouse/api-sdk-node": "^2.0.290",
         "@companieshouse/ch-node-utils": "^2.1.8",
         "@companieshouse/node-session-handler": "^5.2.4",
         "@companieshouse/structured-logging-node": "^2.0.2",


### PR DESCRIPTION
**Jira ticket**: https://companieshouse.atlassian.net/browse/IDVA3-3385

## Brief description of the change(s)

Bumps api-sdk-node to use the latest IDV endpoint changes from [IDVA3-3579 (removal of oracle-query-api call)](https://companieshouse.atlassian.net/browse/IDVA3-3579).

## Working example
>
> Use screenshots or logs to show what your changes do.

<img width="1184" height="1246" alt="image" src="https://github.com/user-attachments/assets/abca4a10-1fed-4069-85e3-74b40962d046" />


## Test notes
>
> Add test notes only if they're **not** already included in the Jira ticket.

Test notes for testers will differ due to environments. For devs:
1. Ensure you've pulled the latest docker-chs-development.
2. Stop all running services.
3. Delete the mongo volume: `docker volume rm docker-chs-development_mongo_data`.
4. `chs-dev up` and check the psc-list screen to confirm dates are populating correctly.

## Checklist

- [x] Adhered to the [coding style guidelines](https://companieshouse.atlassian.net/wiki/spaces/DEV/pages/4290084946/Coding+Standards+and+Styleguides).
- [ ] ~~Added/updated logging appropriately.~~
- [ ] ~~Written tests.~~
- [x] Tested the new code in my local environment.
- [ ] ~~Updated Docker/ECS configs.~~
- [ ] ~~Added all new properties to chs-configs.~~
- [x] Updated release notes.

Strikethrough (`~~like this~~`) anything not applicable to your changes.
