### PR TITLE
Add dependency-check target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,10 +32,6 @@ test:
 test-unit:
 	npm run test
 
-.PHONY: security-check
-security-check:
-	npm audit --audit-level=high
-
 .PHONY: package
 package: build
 ifndef version
@@ -62,3 +58,29 @@ dist: lint test clean package
 submodules:
 	git submodule init
 	git submodule update
+
+.PHONY: dependency-check
+dependency-check:
+	@ if [ -n "$(DEPENDENCY_CHECK_SUPPRESSIONS_HOME)" ]; then \
+		if [ -d "$(DEPENDENCY_CHECK_SUPPRESSIONS_HOME)" ]; then \
+			suppressions_home="$${DEPENDENCY_CHECK_SUPPRESSIONS_HOME}"; \
+		else \
+			printf -- 'DEPENDENCY_CHECK_SUPPRESSIONS_HOME is set, but its value "%s" does not point to a directory\n' "$(DEPENDENCY_CHECK_SUPPRESSIONS_HOME)"; \
+			exit 1; \
+		fi; \
+	fi; \
+	if [ ! -d "$${suppressions_home}" ]; then \
+		suppressions_home_target_dir="./target/dependency-check-suppressions"; \
+		if [ -d "$${suppressions_home_target_dir}" ]; then \
+			suppressions_home="$${suppressions_home_target_dir}"; \
+		else \
+			mkdir -p "./target"; \
+			git clone git@github.com:companieshouse/dependency-check-suppressions.git "$${suppressions_home_target_dir}" && \
+				suppressions_home="$${suppressions_home_target_dir}"; \
+		fi; \
+	fi; \
+	printf -- 'suppressions_home="%s"\n' "$${suppressions_home}"; \
+	DEPENDENCY_CHECK_SUPPRESSIONS_HOME="$${suppressions_home}" "$${suppressions_home}/scripts/depcheck" --repo-name=TodoMyRepoName
+
+.PHONY: security-check
+security-check: dependency-check


### PR DESCRIPTION
**Jira ticket**: IDVA3-3694

## Brief description of the change(s)
Addition copied from - https://github.com/companieshouse/dependency-check-suppressions/blob/main/Makefile_dependency_template

Currently we have:
<img width="581" height="426" alt="Screenshot 2025-09-25 at 12 49 07 pm" src="https://github.com/user-attachments/assets/90041fdd-ac47-49a8-9a11-a97ff6a8a7a6" />

the pipeline task we use is:
<img width="695" height="469" alt="Screenshot 2025-09-25 at 12 43 01 pm" src="https://github.com/user-attachments/assets/b25d96ae-8abe-426a-a987-83df941f416a" />

which runs this make command:
<img width="673" height="806" alt="Screenshot 2025-09-25 at 12 43 20 pm" src="https://github.com/user-attachments/assets/a89a5150-85da-4f12-a671-e3a92568ba9d" />
