### PR TITLE
IDVA3-3456 Add "request extension" URLs to PSC list

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -71,6 +71,7 @@ export const PrefixedUrls = {
 export const ExternalUrls = {
     COMPANY_LOOKUP: "/company-lookup/search",
     COMPANY_LOOKUP_FORWARD: servicePathPrefix + "/confirm-company",
+    REQUEST_AN_EXTENSION: "/persons-with-significant-control-extension/new-submission",
     SIGNOUT: "/signout"
 } as const;
 

--- a/src/views/router_views/individualPscList/individual-psc-list.njk
+++ b/src/views/router_views/individualPscList/individual-psc-list.njk
@@ -57,7 +57,7 @@
                   }
                 },
                 {
-                  href: "",
+                  href: psc.requestExtensionUrl,
                   text: i18n.ind_psc_list_summary_card_extension_link,
                   visuallyHiddenText: i18n.ind_psc_list_summary_card_extension_link + i18n.ind_psc_list_summary_card_verify_link_for + psc.pscName,
                   attributes: {

--- a/test/routers/handlers/individual-psc-list/individualPscListHandler.int.ts
+++ b/test/routers/handlers/individual-psc-list/individualPscListHandler.int.ts
@@ -13,11 +13,11 @@ import { getCompanyIndividualPscList } from "../../../../src/services/companyPsc
 
 jest.mock("../../../../src/services/companyProfileService");
 const mockGetCompanyProfile = getCompanyProfile as jest.Mock;
-mockGetCompanyProfile.mockResolvedValueOnce(validCompanyProfile);
+mockGetCompanyProfile.mockResolvedValue(validCompanyProfile);
 
 jest.mock("../../../../src/services/companyPscService");
 const mockGetCompanyIndividualPscList = getCompanyIndividualPscList as jest.Mock;
-mockGetCompanyIndividualPscList.mockResolvedValueOnce(INDIVIDUAL_PSCS_LIST);
+mockGetCompanyIndividualPscList.mockResolvedValue(INDIVIDUAL_PSCS_LIST);
 jest.mock("../../../../src/services/pscService");
 
 describe("individual PSC list view", () => {
@@ -47,5 +47,32 @@ describe("individual PSC list view", () => {
         expect($("h1").text()).toBe("PSC identity verification status");
         expect($("h2.govuk-summary-card__title").eq(0).text()).toContain(`Mr Jim Testerly`);
         expect($("h2.govuk-summary-card__title").eq(1).text()).toContain(`Mr Test Tester Testington`);
+    });
+
+    it("Should render verify and request extension links for each PSC in canVerifyNowDetails", async () => {
+        const queryParams = new URLSearchParams(`companyNumber=${COMPANY_NUMBER}&lang=en`);
+        const uriWithQuery = `${PrefixedUrls.INDIVIDUAL_PSC_LIST}?${queryParams}`;
+
+        const resp = await request(app).get(uriWithQuery);
+        const $ = cheerio.load(resp.text);
+
+        const summaryCards = $(".govuk-summary-card");
+        expect(summaryCards.length).toBeGreaterThan(0);
+
+        // For each summary card, check for verify and request extension links
+        summaryCards.each((_, card) => {
+            const verifyLink = $(card).find("a[data-event-id='provide-verification-details-link']");
+            const extensionLink = $(card).find("a[data-event-id='request-extension-link']");
+
+            // Verify link should exist and have correct href
+            expect(verifyLink.length).toBe(1);
+            expect(verifyLink.attr("href")).toMatch(/\/persons-with-significant-control-verification\/new-submission\?companyNumber=.*&lang=.*&selectedPscId=.*/);
+            expect(verifyLink.attr("href")).toContain(`companyNumber=${COMPANY_NUMBER}`);
+
+            // Extension link should exist and have correct href
+            expect(extensionLink.length).toBe(1);
+            expect(extensionLink.attr("href")).toMatch(/\/persons-with-significant-control-extension\/new-submission\?companyNumber=.*&selectedPscId=.*&lang=.*/);
+            expect(extensionLink.attr("href")).toContain(`companyNumber=${COMPANY_NUMBER}`);
+        });
     });
 });


### PR DESCRIPTION
**Jira ticket**: https://companieshouse.atlassian.net/browse/IDVA3-3456

## Brief description of the change(s)

Adds request extension URLs in the specified format to PSCs in the psc-list screen. Note that only PSCs that can verify are given the option to request an extension, so only they will have a link generated. Matomo was one of the ACs but it's already in-place.

## Working example
>
> Use screenshots or logs to show what your changes do.

<img width="781" height="334" alt="Screenshot 2025-10-02 at 10 57 54" src="https://github.com/user-attachments/assets/50c8a1cc-0db2-490f-b34f-e7b9212c1642" />

<img width="812" height="49" alt="Screenshot 2025-10-02 at 10 58 05" src="https://github.com/user-attachments/assets/6046be1f-a0ce-435b-b97c-6535ddc8e8bf" />

## Test notes
>
> Add test notes only if they're **not** already included in the Jira ticket.

Included in Jira ticket.

## Checklist

- [x] Adhered to the [coding style guidelines](https://companieshouse.atlassian.net/wiki/spaces/DEV/pages/4290084946/Coding+Standards+and+Styleguides).
- [ ] ~~Added/updated logging appropriately.~~
- [x] Written tests.
- [x] Tested the new code in my local environment.
- [ ] ~~Updated Docker/ECS configs.~~
- [ ] ~~Added all new properties to chs-configs.~~
- [x] Updated release notes.

Strikethrough (`~~like this~~`) anything not applicable to your changes.
